### PR TITLE
Make injectivity_radius with method default to unimplemented

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -557,17 +557,23 @@ all tangent vectors shorter than $d$ (i.e. has a left inverse).
 
 Infimum of the injectivity radius of all manifold points.
 
-    injectivity_radius(M::Manifold, x, method::AbstractRetractionMethod)
+    injectivity_radius(M::Manifold[, x], method::AbstractRetractionMethod)
 
 Distance $d$ such that
 [`retract(M, x, v, method)`](@ref retract(::Manifold, ::Any, ::Any, ::AbstractRetractionMethod))
-is injective for all tangent vectors shorter than $d$ (i.e. has a left inverse).
+is injective for all tangent vectors shorter than $d$ (i.e. has a left inverse) for point
+$x$ if provided or all manifold points otherwise.
 """
 function injectivity_radius(M::Manifold)
     error("injectivity_radius not implemented for manifold $(typeof(M)).")
 end
 injectivity_radius(M::Manifold, x) = injectivity_radius(M)
-injectivity_radius(M::Manifold, x, ::AbstractRetractionMethod) = injectivity_radius(M, x)
+injectivity_radius(M::Manifold, x, method::AbstractRetractionMethod) = injectivity_radius(M, method)
+function injectivity_radius(M::Manifold, method::AbstractRetractionMethod)
+    error("injectivity_radius not implemented for manifold $(typeof(M)) and retraction method $(typeof(method)).")
+end
+injectivity_radius(M::Manifold, x, ::ExponentialRetraction) = injectivity_radius(M, x)
+injectivity_radius(M::Manifold, ::ExponentialRetraction) = injectivity_radius(M)
 
 """
     zero_tangent_vector(M::Manifold, x)

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -7,6 +7,11 @@ using ReverseDiff
 using StaticArrays
 using Test
 
+struct CustomDefinedRetraction <: ManifoldsBase.AbstractRetractionMethod end
+struct CustomUndefinedRetraction <: ManifoldsBase.AbstractRetractionMethod end
+
+ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomDefinedRetraction) = 10.0
+
 @testset "Testing Default (Euclidean)" begin
     M = ManifoldsBase.DefaultManifold(3)
     types = [Vector{Float64},
@@ -30,12 +35,19 @@ using Test
     rm = ManifoldsBase.ExponentialRetraction()
     irm = ManifoldsBase.LogarithmicInverseRetraction()
 
+    rm2 = CustomDefinedRetraction()
+    rm3 = CustomUndefinedRetraction()
+
     for T in types
         @testset "Type $T" begin
             pts = convert.(Ref(T), [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
             @test injectivity_radius(M, pts[1]) == Inf
             @test injectivity_radius(M, pts[1], rm) == Inf
+            @test injectivity_radius(M, rm2) == 10
+            @test injectivity_radius(M, pts[1], rm2) == 10
+            @test_throws ErrorException injectivity_radius(M, rm3)
+            @test_throws ErrorException injectivity_radius(M, pts[1], rm3)
 
             tv1 = log(M, pts[1], pts[2])
 

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -44,6 +44,7 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomDefine
 
             @test injectivity_radius(M, pts[1]) == Inf
             @test injectivity_radius(M, pts[1], rm) == Inf
+            @test injectivity_radius(M, rm) == Inf
             @test injectivity_radius(M, rm2) == 10
             @test injectivity_radius(M, pts[1], rm2) == 10
             @test_throws ErrorException injectivity_radius(M, rm3)


### PR DESCRIPTION
In #16, we changed the default behavior of `injectivity_radius` to make it more conservative. However, `injectivity_radius(M::Manifold, x, method::AbstractRetractionMethod)` still fell back to `injectivity_radius(M, x)`. This is not a conservative choice, as many retraction methods will have a lower injectivity radius than `ExponentialRetraction`. This PR changes the default to an error message, so that for each retraction method defined for one's manifold, they will need to implement the injectivity radius.