### PR TITLE
Resolve ArrayManifold ambiguities and fix functions for complex manifolds

### DIFF
--- a/src/ArrayManifold.jl
+++ b/src/ArrayManifold.jl
@@ -218,6 +218,29 @@ function vector_transport_to!(
     return vto
 end
 
+function vector_transport_to!(
+    M::ArrayManifold,
+    vto,
+    x,
+    v,
+    y,
+    m::ProjectionTransport;
+    kwargs...,
+)
+    is_manifold_point(M, y, true; kwargs...)
+    is_tangent_vector(M, x, v, true; kwargs...)
+    vector_transport_to!(
+        M.manifold,
+        array_value(vto),
+        array_value(x),
+        array_value(v),
+        array_value(y),
+        m,
+    )
+    is_tangent_vector(M, y, vto, true; kwargs...)
+    return vto
+end
+
 function vector_transport_along!(
     M::ArrayManifold,
     vto,
@@ -241,9 +264,28 @@ function vector_transport_along!(
 end
 
 injectivity_radius(M::ArrayManifold) = injectivity_radius(M.manifold)
-function injectivity_radius(M::ArrayManifold, x, args...; kwargs...)
+function injectivity_radius(M::ArrayManifold, method::AbstractRetractionMethod)
+    return injectivity_radius(M.manifold, method)
+end
+function injectivity_radius(M::ArrayManifold, x; kwargs...)
     is_manifold_point(M, x, true; kwargs...)
-    return injectivity_radius(M.manifold, array_value(x), args...)
+    return injectivity_radius(M.manifold, array_value(x))
+end
+function injectivity_radius(
+    M::ArrayManifold,
+    x,
+    method::AbstractRetractionMethod;
+    kwargs...,
+)
+    is_manifold_point(M, x, true; kwargs...)
+    return injectivity_radius(M.manifold, array_value(x), method)
+end
+function injectivity_radius(M::ArrayManifold, method::ExponentialRetraction)
+    return injectivity_radius(M.manifold, method)
+end
+function injectivity_radius(M::ArrayManifold, x, method::ExponentialRetraction; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    return injectivity_radius(M.manifold, array_value(x), method)
 end
 
 function check_manifold_point(M::ArrayManifold, x::MPoint; kwargs...)

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -300,7 +300,7 @@ end
 
 Norm of tangent vector `v` at point `x` from manifold `M`.
 """
-norm(M::Manifold, x, v) = sqrt(inner(M, x, v, v))
+norm(M::Manifold, x, v) = sqrt(real(inner(M, x, v, v)))
 
 """
     distance(M::Manifold, x, y)
@@ -314,7 +314,7 @@ distance(M::Manifold, x, y) = norm(M, x, log(M, x, y))
 
 Angle between tangent vectors `v` and `w` at point `x` from manifold `M`.
 """
-angle(M::Manifold, x, v, w) = acos(inner(M, x, v, w) / norm(M, x, v) / norm(M, x, w))
+angle(M::Manifold, x, v, w) = acos(real(inner(M, x, v, w)) / norm(M, x, v) / norm(M, x, w))
 
 """
     exp!(M::Manifold, y, x, v, t::Real = 1)

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -1,6 +1,11 @@
 using ManifoldsBase
 using LinearAlgebra
 
+struct CustomArrayManifoldRetraction <: ManifoldsBase.AbstractRetractionMethod end
+
+ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomArrayManifoldRetraction) = 10.0
+ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArrayManifoldRetraction) = 11.0
+
 @testset "Array manifold" begin
     M = ManifoldsBase.DefaultManifold(3)
     A = ArrayManifold(M)
@@ -79,5 +84,7 @@ using LinearAlgebra
         @test injectivity_radius(A, x) == Inf
         @test injectivity_radius(A, ManifoldsBase.ExponentialRetraction()) == Inf
         @test injectivity_radius(A, x, ManifoldsBase.ExponentialRetraction()) == Inf
+        @test injectivity_radius(A, CustomArrayManifoldRetraction()) == 10
+        @test injectivity_radius(A, x, CustomArrayManifoldRetraction()) == 11
     end
 end

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -70,10 +70,14 @@ using LinearAlgebra
         @test isapprox(A, zero_tangent_vector(A,x), zero_tangent_vector(M,x))
         vector_transport_to!(A, v2s, x2, v2, y2)
         @test isapprox(A, x2, v2, v2s)
+        vector_transport_to!(A, v2s, x2, v2, y2, ManifoldsBase.ProjectionTransport())
+        @test isapprox(A, x2, v2, v2s)
         zero_tangent_vector!(A, v2s, x)
         @test isapprox(A, v2s, zero_tangent_vector(M,x))
         @test_throws ErrorException vector_transport_along!(A,v2s,x2,v2,ParallelTransport())
         @test injectivity_radius(A) == Inf
         @test injectivity_radius(A, x) == Inf
+        @test injectivity_radius(A, ManifoldsBase.ExponentialRetraction()) == Inf
+        @test injectivity_radius(A, x, ManifoldsBase.ExponentialRetraction()) == Inf
     end
 end

--- a/test/complex_manifold.jl
+++ b/test/complex_manifold.jl
@@ -1,0 +1,27 @@
+using ManifoldsBase
+import ManifoldsBase: representation_size, manifold_dimension, inner
+using LinearAlgebra
+using Test
+
+struct ComplexEuclidean{N} <: Manifold where {N} end
+ComplexEuclidean(n::Int) = ComplexEuclidean{n}()
+representation_size(::ComplexEuclidean{N}) where {N} = (N,)
+manifold_dimension(::ComplexEuclidean{N}) where {N} = 2N
+@inline inner(::ComplexEuclidean, x, v, w) = dot(v, w)
+
+@testset "Complex Euclidean" begin
+    M = ComplexEuclidean(3)
+
+    x = complex.([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    v1 = complex.([0.1, 0.2, 0.3], [0.4, 0.5, 0.6])
+    v2 = complex.([0.3, 0.2, 0.1], [0.6, 0.5, 0.4])
+
+    @test norm(M, x, v1) isa Real
+    @test norm(M, x, v1) ≈ norm(v1)
+    @test angle(M, x, v1, v2) isa Real
+    @test angle(M, x, v1, v2) ≈ acos(real(dot(v1, v2)) / norm(v1) / norm(v2))
+
+    vv1 = vcat(reim(v1)...)
+    vv2 = vcat(reim(v2)...)
+    @test angle(M, x, v1, v2) ≈ acos(dot(normalize(vv1), normalize(vv2)))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test
     include("decorator_manifold.jl")
     include("empty_manifold.jl")
     include("default_manifold.jl")
+    include("complex_manifold.jl")
     include("array_manifold.jl")
     include("domain_errors.jl")
 end


### PR DESCRIPTION
I used [Aqua.jl](https://github.com/tkf/Aqua.jl) to test for method ambiguities (we should probably do this for `Manifolds.jl` as well). It found that `vector_transport_to!` and `injectivity_radius` had several ambiguities that were missed by our tests, so I added failing tests and resolutions.

Several of our defaults did not work correctly for complex manifolds. The Hermitian positive definite inner product on a complex manifold produces a complex number whose real part is a Riemannian inner product on the underlying real manifold (i.e. by identifying `ℂⁿ`  with `ℝ²ⁿ`) and whose imaginary part is a complex differential form.

As I understand it, the concepts of norm, distance, and angle only apply by considering the real part, i.e. the part that arises due to the Riemannian metric. `norm` should always produce a complex number whose imaginary part is 0, so this just discards the imaginary part. `angle` requires discarding the imaginary part, which may be non-zero.