### PR TITLE
Reworking allocation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ArrayManifold.jl
+++ b/src/ArrayManifold.jl
@@ -32,10 +32,14 @@ end
 convert(::Type{V}, x::ArrayMPoint{V}) where {V<:AbstractArray{<:Number}} = x.value
 convert(::Type{ArrayMPoint{V}}, x::V) where {V<:AbstractArray{<:Number}} = ArrayMPoint{V}(x)
 
-eltype(::Type{ArrayMPoint{V}}) where {V} = eltype(V)
+scalar_eltype(::Type{ArrayMPoint{V}}) where {V} = scalar_eltype(V)
+scalar_eltype(x::ArrayMPoint) = scalar_eltype(x.value)
 
 similar(x::ArrayMPoint) = ArrayMPoint(similar(x.value))
 similar(x::ArrayMPoint, ::Type{T}) where {T} = ArrayMPoint(similar(x.value, T))
+
+allocate(x::ArrayMPoint) = ArrayMPoint(allocate(x.value))
+allocate(x::ArrayMPoint, ::Type{T}) where {T} = ArrayMPoint(allocate(x.value, T))
 
 function copyto!(x::ArrayMPoint, y::ArrayMPoint)
     copyto!(x.value, y.value)
@@ -58,10 +62,14 @@ function convert(::Type{ArrayTVector{V}}, v::V) where {V<:AbstractArray{<:Number
     return ArrayTVector{V}(v)
 end
 
-eltype(::Type{ArrayTVector{V}}) where {V} = eltype(V)
+scalar_eltype(::Type{ArrayTVector{V}}) where {V} = scalar_eltype(V)
+scalar_eltype(x::ArrayTVector) = scalar_eltype(x.value)
 
 similar(x::ArrayTVector) = ArrayTVector(similar(x.value))
 similar(x::ArrayTVector, ::Type{T}) where {T} = ArrayTVector(similar(x.value, T))
+
+allocate(x::ArrayTVector) = ArrayTVector(allocate(x.value))
+allocate(x::ArrayTVector, ::Type{T}) where {T} = ArrayTVector(allocate(x.value, T))
 
 function copyto!(x::ArrayTVector, y::ArrayTVector)
     copyto!(x.value, y.value)
@@ -89,7 +97,8 @@ function convert(::Type{ArrayCoTVector{V}}, v::V) where {V<:AbstractArray{<:Numb
     return ArrayCoTVector{V}(v)
 end
 
-eltype(::Type{ArrayCoTVector{V}}) where {V} = eltype(V)
+scalar_eltype(::Type{ArrayCoTVector{V}}) where {V} = scalar_eltype(V)
+scalar_eltype(x::ArrayCoTVector) = scalar_eltype(x.value)
 
 similar(x::ArrayCoTVector) = ArrayCoTVector(similar(x.value))
 similar(x::ArrayCoTVector, ::Type{T}) where {T} = ArrayCoTVector(similar(x.value, T))

--- a/src/ArrayManifold.jl
+++ b/src/ArrayManifold.jl
@@ -32,8 +32,8 @@ end
 convert(::Type{V}, x::ArrayMPoint{V}) where {V<:AbstractArray{<:Number}} = x.value
 convert(::Type{ArrayMPoint{V}}, x::V) where {V<:AbstractArray{<:Number}} = ArrayMPoint{V}(x)
 
-scalar_eltype(::Type{ArrayMPoint{V}}) where {V} = scalar_eltype(V)
-scalar_eltype(x::ArrayMPoint) = scalar_eltype(x.value)
+number_eltype(::Type{ArrayMPoint{V}}) where {V} = number_eltype(V)
+number_eltype(x::ArrayMPoint) = number_eltype(x.value)
 
 similar(x::ArrayMPoint) = ArrayMPoint(similar(x.value))
 similar(x::ArrayMPoint, ::Type{T}) where {T} = ArrayMPoint(similar(x.value, T))
@@ -62,8 +62,8 @@ function convert(::Type{ArrayTVector{V}}, v::V) where {V<:AbstractArray{<:Number
     return ArrayTVector{V}(v)
 end
 
-scalar_eltype(::Type{ArrayTVector{V}}) where {V} = scalar_eltype(V)
-scalar_eltype(x::ArrayTVector) = scalar_eltype(x.value)
+number_eltype(::Type{ArrayTVector{V}}) where {V} = number_eltype(V)
+number_eltype(x::ArrayTVector) = number_eltype(x.value)
 
 similar(x::ArrayTVector) = ArrayTVector(similar(x.value))
 similar(x::ArrayTVector, ::Type{T}) where {T} = ArrayTVector(similar(x.value, T))
@@ -97,8 +97,8 @@ function convert(::Type{ArrayCoTVector{V}}, v::V) where {V<:AbstractArray{<:Numb
     return ArrayCoTVector{V}(v)
 end
 
-scalar_eltype(::Type{ArrayCoTVector{V}}) where {V} = scalar_eltype(V)
-scalar_eltype(x::ArrayCoTVector) = scalar_eltype(x.value)
+number_eltype(::Type{ArrayCoTVector{V}}) where {V} = number_eltype(V)
+number_eltype(x::ArrayCoTVector) = number_eltype(x.value)
 
 similar(x::ArrayCoTVector) = ArrayCoTVector(similar(x.value))
 similar(x::ArrayCoTVector, ::Type{T}) where {T} = ArrayCoTVector(similar(x.value, T))

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -25,4 +25,14 @@ project_tangent!(::DefaultManifold, w, x, v) = copyto!(w, v)
 function vector_transport_to!(::DefaultManifold, vto, x, v, y, ::ParallelTransport)
     return copyto!(vto, v)
 end
+function vector_transport_along!(
+    ::DefaultManifold,
+    vto,
+    x,
+    v,
+    c,
+    ::AbstractVectorTransportMethod
+)
+    return copyto!(vto, v)
+end
 injectivity_radius(::DefaultManifold) = Inf

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -167,13 +167,13 @@ Retraction method can be specified by the last argument, defaulting to
 methods.
 """
 function retract(M::Manifold, x, v)
-    xr = similar_result(M, retract, x, v)
+    xr = allocate_result(M, retract, x, v)
     retract!(M, xr, x, v)
     return xr
 end
 retract(M::Manifold, x, v, t::Real) = retract(M, x, t * v)
 function retract(M::Manifold, x, v, method::AbstractRetractionMethod)
-    xr = similar_result(M, retract, x, v)
+    xr = allocate_result(M, retract, x, v)
     retract!(M, xr, x, v, method)
     return xr
 end
@@ -224,12 +224,12 @@ Inverse retraction method can be specified by the last argument, defaulting to
 for available methods.
 """
 function inverse_retract(M::Manifold, x, y)
-    vr = similar_result(M, inverse_retract, x, y)
+    vr = allocate_result(M, inverse_retract, x, y)
     inverse_retract!(M, vr, x, y)
     return vr
 end
 function inverse_retract(M::Manifold, x, y, method::AbstractInverseRetractionMethod)
-    vr = similar_result(M, inverse_retract, x, y)
+    vr = allocate_result(M, inverse_retract, x, y)
     inverse_retract!(M, vr, x, y, method)
     return vr
 end
@@ -253,7 +253,7 @@ The function works only for selected embedded manifolds and is *not* required to
 closest point.
 """
 function project_point(M::Manifold, x)
-    y = similar_result(M, project_point, x)
+    y = allocate_result(M, project_point, x)
     project_point!(M, y, x)
     return y
 end
@@ -281,7 +281,7 @@ The function works only for selected embedded manifolds and is *not* required to
 closest vector.
 """
 function project_tangent(M::Manifold, x, v)
-    vt = similar_result(M, project_tangent, v, x)
+    vt = allocate_result(M, project_tangent, v, x)
     project_tangent!(M, vt, x, v)
     return vt
 end
@@ -335,7 +335,7 @@ Exponential map of tangent vector `t*v` at point `x` from manifold `M`. `t` may 
 or elements of vector `T`.
 """
 function exp(M::Manifold, x, v)
-    y = similar_result(M, exp, x, v)
+    y = allocate_result(M, exp, x, v)
     exp!(M, y, x, v)
     return y
 end
@@ -357,7 +357,7 @@ end
 Logarithmic map of point `y` at base point `x` on Manifold `M`.
 """
 function log(M::Manifold, x, y)
-    v = similar_result(M, log, x, y)
+    v = allocate_result(M, log, x, y)
     log!(M, v, x, y)
     return v
 end
@@ -462,7 +462,7 @@ function vector_transport_to(M::Manifold, x, v, y)
     return vector_transport_to(M, x, v, y, ParallelTransport())
 end
 function vector_transport_to(M::Manifold, x, v, y, method::AbstractVectorTransportMethod)
-    vto = similar_result(M, vector_transport_to, v, x, y)
+    vto = allocate_result(M, vector_transport_to, v, x, y)
     vector_transport_to!(M, vto, x, v, y, method)
     return vto
 end
@@ -506,7 +506,7 @@ function vector_transport_direction(
     vdir,
     method::AbstractVectorTransportMethod,
 )
-    vto = similar_result(M, vector_transport_direction, v, x, vdir)
+    vto = allocate_result(M, vector_transport_direction, v, x, vdir)
     vector_transport_direction!(M, vto, x, v, vdir, method)
     return vto
 end
@@ -542,7 +542,7 @@ function vector_transport_along(M::Manifold, x, v, c)
     return vector_transport_along(M, x, v, c, ParallelTransport())
 end
 function vector_transport_along(M::Manifold, x, v, c, m::AbstractVectorTransportMethod)
-    vto = similar_result(M, vector_transport_along, v, x)
+    vto = allocate_result(M, vector_transport_along, v, x)
     vector_transport_along!(M, vto, x, v, c, m)
     return vto
 end
@@ -581,7 +581,7 @@ injectivity_radius(M::Manifold, ::ExponentialRetraction) = injectivity_radius(M)
 Vector `v` such that retracting `v` to manifold `M` at `x` produces `x`.
 """
 function zero_tangent_vector(M::Manifold, x)
-    v = similar_result(M, zero_tangent_vector, x)
+    v = allocate_result(M, zero_tangent_vector, x)
     zero_tangent_vector!(M, v, x)
     return v
 end
@@ -615,18 +615,18 @@ function number_eltype(x::Tuple)
 end
 
 """
-    similar_result_type(M::Manifold, f, args::NTuple{N,Any}) where N
+    allocate_result_type(M::Manifold, f, args::NTuple{N,Any}) where N
 
 Return type of element of the array that will represent the result of function `f` for
 manifold `M` on given arguments `args` (passed as a tuple).
 """
-function similar_result_type(M::Manifold, f, args::NTuple{N,Any}) where {N}
+function allocate_result_type(M::Manifold, f, args::NTuple{N,Any}) where {N}
     T = typeof(reduce(+, one(number_eltype(eti)) for eti ∈ args))
     return T
 end
 
 """
-    similar_result(M::Manifold, f, x...)
+    allocate_result(M::Manifold, f, x...)
 
 Allocate an array for the result of function `f` on manifold `M` and arguments `x...` for
 implementing the non-modifying operation using the modifying operation.
@@ -634,8 +634,8 @@ implementing the non-modifying operation using the modifying operation.
 Usefulness of passing a function is demonstrated by methods that allocate results of musical
 isomorphisms.
 """
-function similar_result(M::Manifold, f, x...)
-    T = similar_result_type(M, f, x)
+function allocate_result(M::Manifold, f, x...)
+    T = allocate_result_type(M, f, x)
     return allocate(x[1], T)
 end
 

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -600,8 +600,8 @@ allocate(a::AbstractArray{<:AbstractArray}, T::Type) = map(t -> allocate(t, T), 
 allocate(a::NTuple{N,AbstractArray} where N) = map(allocate, a)
 allocate(a::NTuple{N,AbstractArray} where N, T::Type) = map(t -> allocate(t, T), a)
 
-scalar_eltype(x) = eltype(x)
-scalar_eltype(x::AbstractArray) = scalar_eltype(eltype(x))
+number_eltype(x) = eltype(x)
+number_eltype(x::AbstractArray) = number_eltype(eltype(x))
 
 """
     similar_result_type(M::Manifold, f, args::NTuple{N,Any}) where N
@@ -610,7 +610,7 @@ Return type of element of the array that will represent the result of function `
 manifold `M` on given arguments `args` (passed as a tuple).
 """
 function similar_result_type(M::Manifold, f, args::NTuple{N,Any}) where {N}
-    T = typeof(reduce(+, one(scalar_eltype(eti)) for eti ∈ args))
+    T = typeof(reduce(+, one(number_eltype(eti)) for eti ∈ args))
     return T
 end
 
@@ -739,7 +739,7 @@ export allocate,
        representation_size,
        retract,
        retract!,
-       scalar_eltype,
+       number_eltype,
        vector_transport_along,
        vector_transport_along!,
        vector_transport_direction,

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -594,7 +594,10 @@ Save to `v` a vector such that retracting `v` to manifold `M` at `x` produces `x
 zero_tangent_vector!(M::Manifold, v, x) = log!(M, v, x, x)
 
 allocate(a) = similar(a)
+allocate(a, dims::Int...) = similar(a, dims...)
 allocate(a, T::Type) = similar(a, T)
+allocate(a, T::Type, dims::Int...) = similar(a, T, dims...)
+allocate(a, T::Type, dims::Tuple) = similar(a, T, dims)
 allocate(a::AbstractArray{<:AbstractArray}) = map(allocate, a)
 allocate(a::AbstractArray{<:AbstractArray}, T::Type) = map(t -> allocate(t, T), a)
 allocate(a::NTuple{N,AbstractArray} where N) = map(allocate, a)
@@ -732,6 +735,7 @@ export allocate,
        log!,
        manifold_dimension,
        norm,
+       number_eltype,
        project_point,
        project_point!,
        project_tangent,
@@ -739,7 +743,6 @@ export allocate,
        representation_size,
        retract,
        retract!,
-       number_eltype,
        vector_transport_along,
        vector_transport_along!,
        vector_transport_direction,

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -595,6 +595,7 @@ zero_tangent_vector!(M::Manifold, v, x) = log!(M, v, x, x)
 
 allocate(a) = similar(a)
 allocate(a, dims::Int...) = similar(a, dims...)
+allocate(a, dims::Tuple) = similar(a, dims)
 allocate(a, T::Type) = similar(a, T)
 allocate(a, T::Type, dims::Int...) = similar(a, T, dims...)
 allocate(a, T::Type, dims::Tuple) = similar(a, T, dims)
@@ -604,7 +605,14 @@ allocate(a::NTuple{N,AbstractArray} where N) = map(allocate, a)
 allocate(a::NTuple{N,AbstractArray} where N, T::Type) = map(t -> allocate(t, T), a)
 
 number_eltype(x) = eltype(x)
-number_eltype(x::AbstractArray) = number_eltype(eltype(x))
+function number_eltype(x::AbstractArray{<:AbstractArray})
+    T = typeof(reduce(+, one(number_eltype(eti)) for eti ∈ x))
+    return T
+end
+function number_eltype(x::Tuple)
+    T = typeof(reduce(+, one(number_eltype(eti)) for eti ∈ x))
+    return T
+end
 
 """
     similar_result_type(M::Manifold, f, args::NTuple{N,Any}) where N

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -593,6 +593,22 @@ Save to `v` a vector such that retracting `v` to manifold `M` at `x` produces `x
 """
 zero_tangent_vector!(M::Manifold, v, x) = log!(M, v, x, x)
 
+"""
+    allocate(a)
+    allocate(a, dims::Int...)
+    allocate(a, dims::Tuple)
+    allocate(a, T::Type)
+    allocate(a, T::Type, dims::Int...)
+    allocate(a, T::Type, dims::Tuple)
+
+Allocate an object similar to `a`. It is similar to function `similar`, although
+instead of working only on the outermost layer of a nested structure, it maps recursively
+through outer layers and calls `similar` on the innermost array-like object only.
+Type `T` is the new number element type [`number_eltype`](@ref), if it is not given
+the element type of `a` is retained. The `dims` argument can be given for non-nested
+allocation and is forwarded to the function `similar`.
+"""
+allocate(a, args...)
 allocate(a) = similar(a)
 allocate(a, dims::Int...) = similar(a, dims...)
 allocate(a, dims::Tuple) = similar(a, dims)
@@ -604,6 +620,12 @@ allocate(a::AbstractArray{<:AbstractArray}, T::Type) = map(t -> allocate(t, T), 
 allocate(a::NTuple{N,AbstractArray} where N) = map(allocate, a)
 allocate(a::NTuple{N,AbstractArray} where N, T::Type) = map(t -> allocate(t, T), a)
 
+"""
+    number_eltype(x)
+
+Numeric element type of the a nested representation of a point or a vector.
+To be used in conjuntion with [`allocate`](@ref) or [`allocate_result`](@ref).
+"""
 number_eltype(x) = eltype(x)
 function number_eltype(x::AbstractArray{<:AbstractArray})
     T = typeof(reduce(+, one(number_eltype(eti)) for eti ∈ x))

--- a/test/allocation.jl
+++ b/test/allocation.jl
@@ -1,0 +1,20 @@
+using ManifoldsBase
+using Test
+
+struct AllocManifold <: Manifold end
+
+function ManifoldsBase.exp!(::AllocManifold, v, x, y)
+    v[1] .= x[1] .+ y[1]
+    v[2] .= x[2] .+ y[2]
+    return v
+end
+
+@testset "Allocation" begin
+    a = [[1.0], [2.0], [3.0]]
+    b = [[2.0], [3.0], [-3.0]]
+    M = AllocManifold()
+    v = exp(M, a, b)
+    @test v ≈ [[3.0], [5.0], [0.0]]
+    @test allocate(([1.0], [2.0])) isa Tuple{Vector{Float64}, Vector{Float64}}
+    @test allocate(([1.0], [2.0]), Int) isa Tuple{Vector{Int}, Vector{Int}}
+end

--- a/test/allocation.jl
+++ b/test/allocation.jl
@@ -17,4 +17,27 @@ end
     @test v ≈ [[3.0], [5.0], [0.0]]
     @test allocate(([1.0], [2.0])) isa Tuple{Vector{Float64}, Vector{Float64}}
     @test allocate(([1.0], [2.0]), Int) isa Tuple{Vector{Int}, Vector{Int}}
+    @test allocate([[1.0], [2.0]]) isa Vector{Vector{Float64}}
+    @test allocate([[1.0], [2.0]], Int) isa Vector{Vector{Int}}
+
+    a1 = allocate([1], 2, 3)
+    @test a1 isa Matrix{Int}
+    @test size(a1) == (2, 3)
+    a2 = allocate([1], (2, 3))
+    @test a2 isa Matrix{Int}
+    @test size(a2) == (2, 3)
+    a3 = allocate([1], Float64, 2, 3)
+    @test a3 isa Matrix{Float64}
+    @test size(a3) == (2, 3)
+    a4 = allocate([1], Float64, (2, 3))
+    @test a4 isa Matrix{Float64}
+    @test size(a4) == (2, 3)
+
+    @test number_eltype([2.0]) == Float64
+    @test number_eltype([[2.0], [3]]) == Float64
+    @test number_eltype([[2], [3.0]]) == Float64
+    @test number_eltype([[2], [3]]) == Int
+    @test number_eltype(([2.0], [3])) == Float64
+    @test number_eltype(([2], [3.0])) == Float64
+    @test number_eltype(([2], [3])) == Int
 end

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -33,8 +33,8 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
             p = T(x)
             @test convert(typeof(x),p) == x
             @test convert(typeof(p),y) == T(y)
-            @test scalar_eltype(typeof(p)) == eltype(x)
-            @test scalar_eltype(p) == eltype(x)
+            @test number_eltype(typeof(p)) == eltype(x)
+            @test number_eltype(p) == eltype(x)
             @test typeof(allocate(p)) == typeof(p)
             @test typeof(allocate(p,eltype(x))) == typeof(p)
             q = allocate(p)

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -1,5 +1,6 @@
 using ManifoldsBase
 using LinearAlgebra
+using Test
 
 struct CustomArrayManifoldRetraction <: ManifoldsBase.AbstractRetractionMethod end
 
@@ -62,30 +63,31 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
     end
     @testset "Manifold functions" begin
         @test manifold_dimension(A) == manifold_dimension(M)
-        @test isapprox(y2.value,y)
-        @test distance(A,x,y) == distance(M,x,y)
-        @test norm(A,x,v) == norm(M,x,v)
-        @test inner(A,x,v2,w2; atol=10^(-15)) == inner(M,x,v,w)
-        @test isapprox(A, x2, y2 ) == isapprox(M,x,y)
-        @test isapprox(A,x,y) == isapprox(A,x2,y2)
-        @test isapprox(A,x, v2,v2 ) == isapprox(M,x,v,v)
+        @test isapprox(y2.value, y)
+        @test distance(A, x, y) == distance(M, x, y)
+        @test norm(A, x, v) == norm(M, x, v)
+        @test inner(A, x, v2, w2; atol=10^(-15)) == inner(M, x, v, w)
+        @test isapprox(A, x2, y2) == isapprox(M, x, y)
+        @test isapprox(A, x, y) == isapprox(A, x2, y2)
+        @test isapprox(A, x, v2, v2) == isapprox(M, x, v, v)
         v2s = similar(v2)
         project_tangent!(A,v2s,x2,v2)
         @test isapprox(A, v2, v2s)
         y2s = similar(y2)
         exp!(A,y2s,x2,v2)
-        @test isapprox(A,y2s,y2)
+        @test isapprox(A, y2s, y2)
         log!(A, v2s, x, y)
         @test isapprox(A, x, v2s, v2)
-        @test isapprox(A, exp(A,x,v),y2)
-        @test isapprox(A, zero_tangent_vector(A,x), zero_tangent_vector(M,x))
+        @test isapprox(A, exp(A, x, v), y2)
+        @test isapprox(A, zero_tangent_vector(A, x), zero_tangent_vector(M, x))
         vector_transport_to!(A, v2s, x2, v2, y2)
         @test isapprox(A, x2, v2, v2s)
         vector_transport_to!(A, v2s, x2, v2, y2, ManifoldsBase.ProjectionTransport())
         @test isapprox(A, x2, v2, v2s)
         zero_tangent_vector!(A, v2s, x)
-        @test isapprox(A, v2s, zero_tangent_vector(M,x))
-        @test_throws ErrorException vector_transport_along!(A,v2s,x2,v2,ParallelTransport())
+        @test isapprox(A, x, v2s, zero_tangent_vector(M, x))
+        @test_throws ErrorException vector_transport_along!(A, v2s, x2, v2, ParallelTransport())
+        @test_throws ErrorException vector_transport_along(A, x2, v2, v2, ManifoldsBase.ProjectionTransport())
         @test injectivity_radius(A) == Inf
         @test injectivity_radius(A, x) == Inf
         @test injectivity_radius(A, ManifoldsBase.ExponentialRetraction()) == Inf

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -37,6 +37,8 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
             @test number_eltype(p) == eltype(x)
             @test typeof(allocate(p)) == typeof(p)
             @test typeof(allocate(p,eltype(x))) == typeof(p)
+            @test allocate(p) isa T
+            @test similar(p) isa T
             q = allocate(p)
             copyto!(q,p)
             @test isapprox(A,q,p)

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -71,7 +71,7 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
         @test isapprox(A, x, y) == isapprox(A, x2, y2)
         @test isapprox(A, x, v2, v2) == isapprox(M, x, v, v)
         v2s = similar(v2)
-        project_tangent!(A,v2s,x2,v2)
+        project_tangent!(A, v2s, x2, v2)
         @test isapprox(A, v2, v2s)
         y2s = similar(y2)
         exp!(A,y2s,x2,v2)
@@ -86,8 +86,10 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
         @test isapprox(A, x2, v2, v2s)
         zero_tangent_vector!(A, v2s, x)
         @test isapprox(A, x, v2s, zero_tangent_vector(M, x))
-        @test_throws ErrorException vector_transport_along!(A, v2s, x2, v2, ParallelTransport())
-        @test_throws ErrorException vector_transport_along(A, x2, v2, v2, ManifoldsBase.ProjectionTransport())
+        c = t -> x2
+        v3 = similar(v2)
+        @test isapprox(A, x2, v2, vector_transport_along!(A, v3, x2, v2, c, ParallelTransport()))
+        @test isapprox(A, x2, v2, vector_transport_along(A, x2, v2, c, ManifoldsBase.ProjectionTransport()))
         @test injectivity_radius(A) == Inf
         @test injectivity_radius(A, x) == Inf
         @test injectivity_radius(A, ManifoldsBase.ExponentialRetraction()) == Inf

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -38,7 +38,11 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
             @test typeof(allocate(p)) == typeof(p)
             @test typeof(allocate(p,eltype(x))) == typeof(p)
             @test allocate(p) isa T
+            @test allocate(p, Float32) isa T
+            @test number_eltype(allocate(p, Float32)) == Float32
             @test similar(p) isa T
+            @test similar(p, Float32) isa T
+            @test number_eltype(similar(p, Float32)) == Float32
             q = allocate(p)
             copyto!(q,p)
             @test isapprox(A,q,p)

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -33,11 +33,11 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
             p = T(x)
             @test convert(typeof(x),p) == x
             @test convert(typeof(p),y) == T(y)
-            @test eltype(typeof(p)) == eltype(x)
-            @test eltype(p) == eltype(x)
-            @test typeof(similar(p)) == typeof(p)
-            @test typeof(similar(p,eltype(x))) == typeof(p)
-            q = similar(p)
+            @test scalar_eltype(typeof(p)) == eltype(x)
+            @test scalar_eltype(p) == eltype(x)
+            @test typeof(allocate(p)) == typeof(p)
+            @test typeof(allocate(p,eltype(x))) == typeof(p)
+            q = allocate(p)
             copyto!(q,p)
             @test isapprox(A,q,p)
             @test ManifoldsBase.array_value(p) == x

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -145,6 +145,12 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomDefine
                 @test is_tangent_vector(M, pts[3], v1t1)
                 @test is_tangent_vector(M, pts[3], v1t3)
                 @test isapprox(M, pts[3], v1t1, v1t3)
+                c = t -> pts[1]
+                v1t4 = vector_transport_along(M, pts[1], v1, c)
+                @test isapprox(M, pts[1], v1, v1t4)
+                v1t5 = allocate(v1)
+                vector_transport_along!(M, v1t5, pts[1], v1, c)
+                @test isapprox(M, pts[1], v1, v1t5)
             end
 
             @testset "ForwardDiff support" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 
 @testset "ManifoldsBase" begin
+    include("allocation.jl")
     include("decorator_manifold.jl")
     include("empty_manifold.jl")
     include("default_manifold.jl")


### PR DESCRIPTION
Representing points on a power manifold with nested arrays of arrays (discussed here: https://github.com/JuliaNLSolvers/Manifolds.jl/pull/92#issuecomment-575062069 for example) forces us to change a bit the way points are allocated. I've introduced here a new pattern of `scalar_eltype` (that unwraps all arrays and tuples until it reaches a scalar `eltype`) and `allocate` which is like `similar` but for nested arrays it actually calls similar at the lowest level only and at higher levels of nesting just `map`s through the structure.

Unfortunately, it's a breaking change that can't be done in `Manifolds.jl` first, so I've opened a PR here. I'll open a matching PR in `Manifolds.jl` later when we agree on the direction it should take.

Along with this changes, I'd like to tackle https://github.com/JuliaNLSolvers/Manifolds.jl/issues/95 in the PR I'll open in `Manifolds.jl`.

@sethaxen What do you think about these changes?