### PR TITLE
New base_manifold and documentation rework

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ArrayManifold.jl
+++ b/src/ArrayManifold.jl
@@ -13,11 +13,6 @@ struct ArrayManifold{M<:Manifold} <: Manifold
     manifold::M
 end
 
-convert(::Type{M}, m::ArrayManifold{M}) where {M<:Manifold} = m.manifold
-convert(::Type{ArrayManifold{M}}, m::M) where {M<:Manifold} = ArrayManifold(m)
-
-is_decorator_manifold(::ArrayManifold) = Val(true)
-
 """
     ArrayMPoint <: MPoint
 
@@ -27,23 +22,6 @@ the value from [`ArrayTVector`](@ref)s and [`ArrayCoTVector`](@ref)s.
 """
 struct ArrayMPoint{V<:AbstractArray{<:Number}} <: MPoint
     value::V
-end
-
-convert(::Type{V}, x::ArrayMPoint{V}) where {V<:AbstractArray{<:Number}} = x.value
-convert(::Type{ArrayMPoint{V}}, x::V) where {V<:AbstractArray{<:Number}} = ArrayMPoint{V}(x)
-
-number_eltype(::Type{ArrayMPoint{V}}) where {V} = number_eltype(V)
-number_eltype(x::ArrayMPoint) = number_eltype(x.value)
-
-similar(x::ArrayMPoint) = ArrayMPoint(similar(x.value))
-similar(x::ArrayMPoint, ::Type{T}) where {T} = ArrayMPoint(similar(x.value, T))
-
-allocate(x::ArrayMPoint) = ArrayMPoint(allocate(x.value))
-allocate(x::ArrayMPoint, ::Type{T}) where {T} = ArrayMPoint(allocate(x.value, T))
-
-function copyto!(x::ArrayMPoint, y::ArrayMPoint)
-    copyto!(x.value, y.value)
-    return x
 end
 
 """
@@ -57,30 +35,6 @@ struct ArrayTVector{V<:AbstractArray{<:Number}} <: TVector
     value::V
 end
 
-convert(::Type{V}, v::ArrayTVector{V}) where {V<:AbstractArray{<:Number}} = v.value
-function convert(::Type{ArrayTVector{V}}, v::V) where {V<:AbstractArray{<:Number}}
-    return ArrayTVector{V}(v)
-end
-
-number_eltype(::Type{ArrayTVector{V}}) where {V} = number_eltype(V)
-number_eltype(x::ArrayTVector) = number_eltype(x.value)
-
-similar(x::ArrayTVector) = ArrayTVector(similar(x.value))
-similar(x::ArrayTVector, ::Type{T}) where {T} = ArrayTVector(similar(x.value, T))
-
-allocate(x::ArrayTVector) = ArrayTVector(allocate(x.value))
-allocate(x::ArrayTVector, ::Type{T}) where {T} = ArrayTVector(allocate(x.value, T))
-
-function copyto!(x::ArrayTVector, y::ArrayTVector)
-    copyto!(x.value, y.value)
-    return x
-end
-
-(+)(v1::ArrayTVector, v2::ArrayTVector) = ArrayTVector(v1.value + v2.value)
-(-)(v1::ArrayTVector, v2::ArrayTVector) = ArrayTVector(v1.value - v2.value)
-(-)(v::ArrayTVector) = ArrayTVector(-v.value)
-(*)(a::Number, v::ArrayTVector) = ArrayTVector(a * v.value)
-
 """
     ArrayCoTVector <: CoTVector
 
@@ -92,26 +46,21 @@ struct ArrayCoTVector{V<:AbstractArray{<:Number}} <: TVector
     value::V
 end
 
-convert(::Type{V}, v::ArrayCoTVector{V}) where {V<:AbstractArray{<:Number}} = v.value
-function convert(::Type{ArrayCoTVector{V}}, v::V) where {V<:AbstractArray{<:Number}}
-    return ArrayCoTVector{V}(v)
-end
-
-number_eltype(::Type{ArrayCoTVector{V}}) where {V} = number_eltype(V)
-number_eltype(x::ArrayCoTVector) = number_eltype(x.value)
-
-similar(x::ArrayCoTVector) = ArrayCoTVector(similar(x.value))
-similar(x::ArrayCoTVector, ::Type{T}) where {T} = ArrayCoTVector(similar(x.value, T))
-
-function copyto!(x::ArrayCoTVector, y::ArrayCoTVector)
-    copyto!(x.value, y.value)
-    return x
-end
-
 (+)(v1::ArrayCoTVector, v2::ArrayCoTVector) = ArrayCoTVector(v1.value + v2.value)
 (-)(v1::ArrayCoTVector, v2::ArrayCoTVector) = ArrayCoTVector(v1.value - v2.value)
 (-)(v::ArrayCoTVector) = ArrayCoTVector(-v.value)
 (*)(a::Number, v::ArrayCoTVector) = ArrayCoTVector(a * v.value)
+
+(+)(v1::ArrayTVector, v2::ArrayTVector) = ArrayTVector(v1.value + v2.value)
+(-)(v1::ArrayTVector, v2::ArrayTVector) = ArrayTVector(v1.value - v2.value)
+(-)(v::ArrayTVector) = ArrayTVector(-v.value)
+(*)(a::Number, v::ArrayTVector) = ArrayTVector(a * v.value)
+
+
+allocate(x::ArrayMPoint) = ArrayMPoint(allocate(x.value))
+allocate(x::ArrayMPoint, ::Type{T}) where {T} = ArrayMPoint(allocate(x.value, T))
+allocate(x::ArrayTVector) = ArrayTVector(allocate(x.value))
+allocate(x::ArrayTVector, ::Type{T}) where {T} = ArrayTVector(allocate(x.value, T))
 
 """
     array_value(x)
@@ -125,37 +74,44 @@ array_value(x::ArrayMPoint) = x.value
 array_value(v::ArrayTVector) = v.value
 array_value(v::ArrayCoTVector) = v.value
 
-function isapprox(M::ArrayManifold, x, y; kwargs...)
-    is_manifold_point(M, x, true; kwargs...)
-    is_manifold_point(M, y, true; kwargs...)
-    return isapprox(M.manifold, array_value(x), array_value(y); kwargs...)
+function check_manifold_point(M::ArrayManifold, x::MPoint; kwargs...)
+    return check_manifold_point(M.manifold, array_value(x); kwargs...)
 end
 
-function isapprox(M::ArrayManifold, x, v, w; kwargs...)
-    is_manifold_point(M, x, true; kwargs...)
-    is_tangent_vector(M, x, v, true; kwargs...)
-    is_tangent_vector(M, x, w, true; kwargs...)
-    return isapprox(M.manifold, array_value(x), array_value(v), array_value(w); kwargs...)
+function check_tangent_vector(M::ArrayManifold, x::MPoint, v::TVector; kwargs...)
+    return check_tangent_vector(M.manifold, array_value(x), array_value(v); kwargs...)
 end
 
-function project_tangent!(M::ArrayManifold, w, x, v; kwargs...)
-    is_manifold_point(M, x, true; kwargs...)
-    project_tangent!(M.manifold, w.value, array_value(x), array_value(v))
-    is_tangent_vector(M, x, w, true; kwargs...)
-    return w
+convert(::Type{V}, v::ArrayCoTVector{V}) where {V<:AbstractArray{<:Number}} = v.value
+function convert(::Type{ArrayCoTVector{V}}, v::V) where {V<:AbstractArray{<:Number}}
+    return ArrayCoTVector{V}(v)
+end
+convert(::Type{M}, m::ArrayManifold{M}) where {M<:Manifold} = m.manifold
+convert(::Type{ArrayManifold{M}}, m::M) where {M<:Manifold} = ArrayManifold(m)
+convert(::Type{V}, x::ArrayMPoint{V}) where {V<:AbstractArray{<:Number}} = x.value
+convert(::Type{ArrayMPoint{V}}, x::V) where {V<:AbstractArray{<:Number}} = ArrayMPoint{V}(x)
+convert(::Type{V}, v::ArrayTVector{V}) where {V<:AbstractArray{<:Number}} = v.value
+function convert(::Type{ArrayTVector{V}}, v::V) where {V<:AbstractArray{<:Number}}
+    return ArrayTVector{V}(v)
+end
+
+function copyto!(x::ArrayMPoint, y::ArrayMPoint)
+    copyto!(x.value, y.value)
+    return x
+end
+function copyto!(x::ArrayCoTVector, y::ArrayCoTVector)
+    copyto!(x.value, y.value)
+    return x
+end
+function copyto!(x::ArrayTVector, y::ArrayTVector)
+    copyto!(x.value, y.value)
+    return x
 end
 
 function distance(M::ArrayManifold, x, y; kwargs...)
     is_manifold_point(M, x, true; kwargs...)
     is_manifold_point(M, y, true; kwargs...)
     return distance(M.manifold, array_value(x), array_value(y))
-end
-
-function inner(M::ArrayManifold, x, v, w; kwargs...)
-    is_manifold_point(M, x, true; kwargs...)
-    is_tangent_vector(M, x, v, true; kwargs...)
-    is_tangent_vector(M, x, w, true; kwargs...)
-    return inner(M.manifold, array_value(x), array_value(v), array_value(w))
 end
 
 function exp(M::ArrayManifold, x, v; kwargs...)
@@ -174,6 +130,52 @@ function exp!(M::ArrayManifold, y, x, v; kwargs...)
     return y
 end
 
+injectivity_radius(M::ArrayManifold) = injectivity_radius(M.manifold)
+function injectivity_radius(M::ArrayManifold, method::AbstractRetractionMethod)
+    return injectivity_radius(M.manifold, method)
+end
+function injectivity_radius(M::ArrayManifold, x; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    return injectivity_radius(M.manifold, array_value(x))
+end
+function injectivity_radius(
+    M::ArrayManifold,
+    x,
+    method::AbstractRetractionMethod;
+    kwargs...,
+)
+    is_manifold_point(M, x, true; kwargs...)
+    return injectivity_radius(M.manifold, array_value(x), method)
+end
+function injectivity_radius(M::ArrayManifold, method::ExponentialRetraction)
+    return injectivity_radius(M.manifold, method)
+end
+function injectivity_radius(M::ArrayManifold, x, method::ExponentialRetraction; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    return injectivity_radius(M.manifold, array_value(x), method)
+end
+
+function inner(M::ArrayManifold, x, v, w; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    is_tangent_vector(M, x, v, true; kwargs...)
+    is_tangent_vector(M, x, w, true; kwargs...)
+    return inner(M.manifold, array_value(x), array_value(v), array_value(w))
+end
+
+function isapprox(M::ArrayManifold, x, y; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    is_manifold_point(M, y, true; kwargs...)
+    return isapprox(M.manifold, array_value(x), array_value(y); kwargs...)
+end
+function isapprox(M::ArrayManifold, x, v, w; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    is_tangent_vector(M, x, v, true; kwargs...)
+    is_tangent_vector(M, x, w, true; kwargs...)
+    return isapprox(M.manifold, array_value(x), array_value(v), array_value(w); kwargs...)
+end
+
+is_decorator_manifold(::ArrayManifold) = Val(true)
+
 function log(M::ArrayManifold, x, y; kwargs...)
     is_manifold_point(M, x, true; kwargs...)
     is_manifold_point(M, y, true; kwargs...)
@@ -190,18 +192,47 @@ function log!(M::ArrayManifold, v, x, y; kwargs...)
     return v
 end
 
-function zero_tangent_vector!(M::ArrayManifold, v, x; kwargs...)
-    is_manifold_point(M, x, true; kwargs...)
-    zero_tangent_vector!(M.manifold, array_value(v), array_value(x); kwargs...)
-    is_tangent_vector(M, x, v, true; kwargs...)
-    return v
-end
+number_eltype(::Type{ArrayMPoint{V}}) where {V} = number_eltype(V)
+number_eltype(x::ArrayMPoint) = number_eltype(x.value)
+number_eltype(::Type{ArrayCoTVector{V}}) where {V} = number_eltype(V)
+number_eltype(x::ArrayCoTVector) = number_eltype(x.value)
+number_eltype(::Type{ArrayTVector{V}}) where {V} = number_eltype(V)
+number_eltype(x::ArrayTVector) = number_eltype(x.value)
 
-function zero_tangent_vector(M::ArrayManifold, x; kwargs...)
+function project_tangent!(M::ArrayManifold, w, x, v; kwargs...)
     is_manifold_point(M, x, true; kwargs...)
-    w = zero_tangent_vector(M.manifold, array_value(x))
+    project_tangent!(M.manifold, w.value, array_value(x), array_value(v))
     is_tangent_vector(M, x, w, true; kwargs...)
     return w
+end
+
+similar(x::ArrayMPoint) = ArrayMPoint(similar(x.value))
+similar(x::ArrayMPoint, ::Type{T}) where {T} = ArrayMPoint(similar(x.value, T))
+similar(x::ArrayCoTVector) = ArrayCoTVector(similar(x.value))
+similar(x::ArrayCoTVector, ::Type{T}) where {T} = ArrayCoTVector(similar(x.value, T))
+similar(x::ArrayTVector) = ArrayTVector(similar(x.value))
+similar(x::ArrayTVector, ::Type{T}) where {T} = ArrayTVector(similar(x.value, T))
+
+function vector_transport_along!(
+    M::ArrayManifold,
+    vto,
+    x,
+    v,
+    c,
+    m::AbstractVectorTransportMethod;
+    kwargs...,
+)
+    is_tangent_vector(M, x, v, true; kwargs...)
+    vector_transport_along!(
+        M.manifold,
+        array_value(vto),
+        array_value(x),
+        array_value(v),
+        c,
+        m,
+    )
+    is_tangent_vector(M, c(1), vto, true; kwargs...)
+    return vto
 end
 
 function vector_transport_to!(
@@ -250,57 +281,16 @@ function vector_transport_to!(
     return vto
 end
 
-function vector_transport_along!(
-    M::ArrayManifold,
-    vto,
-    x,
-    v,
-    c,
-    m::AbstractVectorTransportMethod;
-    kwargs...,
-)
+function zero_tangent_vector(M::ArrayManifold, x; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    w = zero_tangent_vector(M.manifold, array_value(x))
+    is_tangent_vector(M, x, w, true; kwargs...)
+    return w
+end
+
+function zero_tangent_vector!(M::ArrayManifold, v, x; kwargs...)
+    is_manifold_point(M, x, true; kwargs...)
+    zero_tangent_vector!(M.manifold, array_value(v), array_value(x); kwargs...)
     is_tangent_vector(M, x, v, true; kwargs...)
-    vector_transport_along!(
-        M.manifold,
-        array_value(vto),
-        array_value(x),
-        array_value(v),
-        c,
-        m,
-    )
-    is_tangent_vector(M, c(1), vto, true; kwargs...)
-    return vto
-end
-
-injectivity_radius(M::ArrayManifold) = injectivity_radius(M.manifold)
-function injectivity_radius(M::ArrayManifold, method::AbstractRetractionMethod)
-    return injectivity_radius(M.manifold, method)
-end
-function injectivity_radius(M::ArrayManifold, x; kwargs...)
-    is_manifold_point(M, x, true; kwargs...)
-    return injectivity_radius(M.manifold, array_value(x))
-end
-function injectivity_radius(
-    M::ArrayManifold,
-    x,
-    method::AbstractRetractionMethod;
-    kwargs...,
-)
-    is_manifold_point(M, x, true; kwargs...)
-    return injectivity_radius(M.manifold, array_value(x), method)
-end
-function injectivity_radius(M::ArrayManifold, method::ExponentialRetraction)
-    return injectivity_radius(M.manifold, method)
-end
-function injectivity_radius(M::ArrayManifold, x, method::ExponentialRetraction; kwargs...)
-    is_manifold_point(M, x, true; kwargs...)
-    return injectivity_radius(M.manifold, array_value(x), method)
-end
-
-function check_manifold_point(M::ArrayManifold, x::MPoint; kwargs...)
-    return check_manifold_point(M.manifold, array_value(x); kwargs...)
-end
-
-function check_tangent_vector(M::ArrayManifold, x::MPoint, v::TVector; kwargs...)
-    return check_tangent_vector(M.manifold, array_value(x), array_value(v); kwargs...)
+    return v
 end

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -12,27 +12,39 @@ situations to verify correctness of involved variabes.
 struct DefaultManifold{T<:Tuple} <: Manifold where {T} end
 DefaultManifold(n::Vararg{Int,N}) where {N} = DefaultManifold{Tuple{n...}}()
 
-@generated representation_size(::DefaultManifold{T}) where {T} = Tuple(T.parameters...)
-@generated manifold_dimension(::DefaultManifold{T}) where {T} = *(T.parameters...)
-@inline inner(::DefaultManifold, x, v, w) = dot(v, w)
 distance(::DefaultManifold, x, y) = norm(x - y)
-norm(::DefaultManifold, x, v) = norm(v)
+
 exp!(::DefaultManifold, y, x, v) = (y .= x .+ v)
+
+@generated manifold_dimension(::DefaultManifold{T}) where {T} = *(T.parameters...)
+
+injectivity_radius(::DefaultManifold) = Inf
+
+@inline inner(::DefaultManifold, x, v, w) = dot(v, w)
+
 log!(::DefaultManifold, v, x, y) = (v .= y .- x)
-zero_tangent_vector!(::DefaultManifold, v, x) = fill!(v, 0)
+
+norm(::DefaultManifold, x, v) = norm(v)
+
 project_point!(::DefaultManifold, y, x) = copyto!(y, x)
+
 project_tangent!(::DefaultManifold, w, x, v) = copyto!(w, v)
-function vector_transport_to!(::DefaultManifold, vto, x, v, y, ::ParallelTransport)
-    return copyto!(vto, v)
-end
+
+@generated representation_size(::DefaultManifold{T}) where {T} = Tuple(T.parameters...)
+
 function vector_transport_along!(
     ::DefaultManifold,
     vto,
     x,
     v,
     c,
-    ::AbstractVectorTransportMethod
+    ::AbstractVectorTransportMethod,
 )
     return copyto!(vto, v)
 end
-injectivity_radius(::DefaultManifold) = Inf
+
+function vector_transport_to!(::DefaultManifold, vto, x, v, y, ::ParallelTransport)
+    return copyto!(vto, v)
+end
+
+zero_tangent_vector!(::DefaultManifold, v, x) = fill!(v, 0)

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -17,6 +17,48 @@ usually as the first argument of the function. Examples are the [`exp`](@ref)one
 abstract type Manifold end
 
 """
+    AbstractEstimationMethod
+
+Abstract type for defining statistical estimation methods.
+"""
+abstract type AbstractEstimationMethod end
+
+"""
+    AbstractInverseRetractionMethod
+
+Abstract type for methods for inverting a retraction (see [`inverse_retract`](@ref)).
+"""
+abstract type AbstractInverseRetractionMethod end
+
+"""
+    AbstractRetractionMethod
+
+Abstract type for methods for [`retract`](@ref)ing a tangent vector to a manifold.
+"""
+abstract type AbstractRetractionMethod end
+
+"""
+    AbstractVectorTransportMethod
+
+Abstract type for methods for transporting vectors.
+"""
+abstract type AbstractVectorTransportMethod end
+
+"""
+    ExponentialRetraction
+
+Retraction using the exponential map.
+"""
+struct ExponentialRetraction <: AbstractRetractionMethod end
+
+"""
+    LogarithmicInverseRetraction
+
+Inverse retraction using the [`log`](@ref)arithmic map.
+"""
+struct LogarithmicInverseRetraction <: AbstractInverseRetractionMethod end
+
+"""
     MPoint
 
 Type for a point on a manifold. While a [`Manifold`](@ref) does not necessarily require this
@@ -25,6 +67,32 @@ can be used for more complicated representations, semantic verification, or even
 for different representations of points on a manifold.
 """
 abstract type MPoint end
+
+"""
+    OutOfInjectivityRadiusError
+
+An error thrown when a function (for example [`log`](@ref)arithmic map or
+[`inverse_retract`](@ref)) is given arguments outside of its [`injectivity_radius`](@ref).
+"""
+struct OutOfInjectivityRadiusError <: Exception end
+
+"""
+    ParallelTransport <: AbstractVectorTransportMethod
+
+Specify to use parallel transport as vector transport method within
+[`vector_transport_to`](@ref), [`vector_transport_direction`](@ref), or
+[`vector_transport_along`](@ref).
+"""
+struct ParallelTransport <: AbstractVectorTransportMethod end
+
+"""
+    ProjectionTransport <: AbstractVectorTransportMethod
+
+Specify to use projection onto tangent space as vector transport method within
+[`vector_transport_to`](@ref), [`vector_transport_direction`](@ref), or
+[`vector_transport_along`](@ref). See [`project_tangent`](@ref) for details.
+"""
+struct ProjectionTransport <: AbstractVectorTransportMethod end
 
 """
     TVector
@@ -47,551 +115,6 @@ or even dispatch for different representations of cotangent vectors and their ty
 manifold.
 """
 abstract type CoTVector end
-
-"""
-    is_decorator_manifold(M::Manifold)
-
-Indicate whether a manifold is a decorator manifold, i.e. whether it encapsulates a
-[`Manifold`](@ref) with additional features and stores internally the original manifold
-instance. An example is the [`ArrayManifold`](@ref).
-
-Certain functions are just calling themselves on the internal manifold and hence do not need
-to be reimplemented for decorators again, for example [`manifold_dimension`](@ref) and
-especially [`base_manifold`](@ref).
-
-It is assumed that the undecorated (base) manifold is stored in `M.manifold`. Alternatively,
-overload [`base_manifold`](@ref).
-"""
-is_decorator_manifold(::Manifold) = Val(false)
-
-"""
-    base_manifold(M::Manifold)
-
-Return the internally stored manifold for decorated manifolds and the base manifold for
-vector bundles or power manifolds.
-"""
-base_manifold(M::Manifold) = base_manifold(M, is_decorator_manifold(M))
-base_manifold(M::Manifold, ::Val{true}) = base_manifold(M.manifold)
-base_manifold(M::Manifold, ::Val{false}) = M
-
-@doc doc"""
-    representation_size(M::Manifold)
-
-The size of an array representing a point on manifold `M`.
-"""
-representation_size(M::Manifold) = representation_size(M, is_decorator_manifold(M))
-representation_size(M::Manifold, ::Val{true}) = representation_size(base_manifold(M))
-function representation_size(M::Manifold, ::Val{false})
-    error("representation_size not implemented for manifold $(typeof(M)).")
-end
-
-@doc doc"""
-    manifold_dimension(M::Manifold)
-
-The dimension $n$ of real space $\mathbb R^n$ to which the neighborhood of each point of the
-manifold is homeomorphic.
-"""
-manifold_dimension(M::Manifold) = manifold_dimension(M, is_decorator_manifold(M))
-manifold_dimension(M::Manifold, ::Val{true}) = manifold_dimension(base_manifold(M))
-function manifold_dimension(M::Manifold, ::Val{false})
-    error("manifold_dimension not implemented for manifold $(typeof(M)).")
-end
-
-"""
-    isapprox(M::Manifold, x, y; kwargs...)
-
-Check if points `x` and `y` from manifold `M` are approximately equal.
-
-Keyword arguments can be used to specify tolerances.
-"""
-isapprox(M::Manifold, x, y; kwargs...) = isapprox(x, y; kwargs...)
-
-"""
-    isapprox(M::Manifold, x, v, w; kwargs...)
-
-Check if vectors `v` and `w` tangent at `x` from manifold `M` are approximately equal.
-
-Keyword arguments can be used to specify tolerances.
-"""
-isapprox(M::Manifold, x, v, w; kwargs...) = isapprox(v, w; kwargs...)
-
-"""
-    OutOfInjectivityRadiusError
-
-An error thrown when a function (for example [`log`](@ref)arithmic map or
-[`inverse_retract`](@ref)) is given arguments outside of its [`injectivity_radius`](@ref).
-"""
-struct OutOfInjectivityRadiusError <: Exception end
-
-"""
-    AbstractRetractionMethod
-
-Abstract type for methods for [`retract`](@ref)ing a tangent vector to a manifold.
-"""
-abstract type AbstractRetractionMethod end
-
-"""
-    ExponentialRetraction
-
-Retraction using the exponential map.
-"""
-struct ExponentialRetraction <: AbstractRetractionMethod end
-
-"""
-    retract!(M::Manifold, y, x, v[, t::Real=1])
-    retract!(M::Manifold, y, x, v[, t::Real=1], method::AbstractRetractionMethod)
-
-Retraction (cheaper, approximate version of [`exp`](@ref)onential map) of tangent vector
-`t*v` at point `x` from manifold `M`. Result is saved to `y`.
-
-Retraction method can be specified by the last argument, defaulting to
-[`ExponentialRetraction`](@ref). See the documentation of respective manifolds for available
-methods.
-"""
-retract!(M::Manifold, y, x, v) = retract!(M, y, x, v, ExponentialRetraction())
-retract!(M::Manifold, y, x, v, t::Real) = retract!(M, y, x, t * v)
-retract!(M::Manifold, y, x, v, method::ExponentialRetraction) = exp!(M, y, x, v)
-function retract!(M::Manifold, y, x, v, t::Real, method::AbstractRetractionMethod)
-    return retract!(M, y, x, t * v, method)
-end
-
-"""
-    retract(M::Manifold, x, v[, t::Real=1])
-    retract(M::Manifold, x, v[, t::Real=1], method::AbstractRetractionMethod)
-
-Retraction (cheaper, approximate version of [`exp`](@ref)onential map) of tangent vector
-`t*v` at point `x` from manifold `M`.
-
-Retraction method can be specified by the last argument, defaulting to
-[`ExponentialRetraction`](@ref). See the documentation of respective manifolds for available
-methods.
-"""
-function retract(M::Manifold, x, v)
-    xr = allocate_result(M, retract, x, v)
-    retract!(M, xr, x, v)
-    return xr
-end
-retract(M::Manifold, x, v, t::Real) = retract(M, x, t * v)
-function retract(M::Manifold, x, v, method::AbstractRetractionMethod)
-    xr = allocate_result(M, retract, x, v)
-    retract!(M, xr, x, v, method)
-    return xr
-end
-function retract(M::Manifold, x, v, t::Real, method::AbstractRetractionMethod)
-    return retract(M, x, t * v, method)
-end
-
-"""
-    AbstractInverseRetractionMethod
-
-Abstract type for methods for inverting a retraction (see [`inverse_retract`](@ref)).
-"""
-abstract type AbstractInverseRetractionMethod end
-
-"""
-    LogarithmicInverseRetraction
-
-Inverse retraction using the [`log`](@ref)arithmic map.
-"""
-struct LogarithmicInverseRetraction <: AbstractInverseRetractionMethod end
-
-"""
-    inverse_retract!(M::Manifold, v, x, y[, method::AbstractInverseRetractionMethod])
-
-Inverse retraction (cheaper, approximate version of [`log`](@ref)arithmic map) of points `x`
-and `y`. Result is saved to `v`.
-
-Inverse retraction method can be specified by the last argument, defaulting to
-[`LogarithmicInverseRetraction`](@ref). See the documentation of respective manifolds for
-available methods.
-"""
-function inverse_retract!(M::Manifold, v, x, y)
-    return inverse_retract!(M, v, x, y, LogarithmicInverseRetraction())
-end
-function inverse_retract!(M::Manifold, v, x, y, method::LogarithmicInverseRetraction)
-    return log!(M, v, x, y)
-end
-
-"""
-    inverse_retract(M::Manifold, x, y)
-    inverse_retract(M::Manifold, x, y, method::AbstractInverseRetractionMethod
-
-Inverse retraction (cheaper, approximate version of [`log`](@ref)arithmic map) of points `x`
-and `y` from manifold `M`.
-
-Inverse retraction method can be specified by the last argument, defaulting to
-[`LogarithmicInverseRetraction`](@ref). See the documentation of respective manifolds
-for available methods.
-"""
-function inverse_retract(M::Manifold, x, y)
-    vr = allocate_result(M, inverse_retract, x, y)
-    inverse_retract!(M, vr, x, y)
-    return vr
-end
-function inverse_retract(M::Manifold, x, y, method::AbstractInverseRetractionMethod)
-    vr = allocate_result(M, inverse_retract, x, y)
-    inverse_retract!(M, vr, x, y, method)
-    return vr
-end
-
-"""
-    project_point!(M::Manifold, y, x)
-
-Project point `x` from the ambient space onto the manifold `M`. The point `y` is overwritten
-by the projection. The function works only for selected embedded manifolds and is *not*
-required to return the closest point.
-"""
-function project_point!(M::Manifold, y, x)
-    error("project_point! not implemented for a $(typeof(M)) and points $(typeof(y)) and $(typeof(x)).")
-end
-
-"""
-    project_point(M::Manifold, x)
-
-Project point from the ambient space onto the manifold `M`. The point `x` is not modified.
-The function works only for selected embedded manifolds and is *not* required to return the
-closest point.
-"""
-function project_point(M::Manifold, x)
-    y = allocate_result(M, project_point, x)
-    project_point!(M, y, x)
-    return y
-end
-
-"""
-    project_tangent!(M::Manifold, w, x, v)
-
-Project ambient space representation of a vector `v` to a tangent vector at point `x` from
-the manifold `M`. The result is saved in vector `w`.
-
-The function works only for selected embedded manifolds and is *not* required to return the
-closest vector.
-"""
-function project_tangent!(M::Manifold, w, x, v)
-    error("project_tangent! not implemented for a $(typeof(M)) and point $(typeof(x)) with input $(typeof(v)).")
-end
-
-"""
-    project_tangent(M::Manifold, x, v)
-
-Project ambient space representation of a vector `v` to a tangent vector at point `x` from
-the manifold `M`.
-
-The function works only for selected embedded manifolds and is *not* required to return the
-closest vector.
-"""
-function project_tangent(M::Manifold, x, v)
-    vt = allocate_result(M, project_tangent, v, x)
-    project_tangent!(M, vt, x, v)
-    return vt
-end
-
-"""
-    inner(M::Manifold, x, v, w)
-
-Inner product of tangent vectors `v` and `w` at point `x` from manifold `M`.
-"""
-function inner(M::Manifold, x, v, w)
-    error("inner not implemented on a $(typeof(M)) for input point $(typeof(x)) and tangent vectors $(typeof(v)) and $(typeof(w)).")
-end
-
-"""
-    norm(M::Manifold, x, v)
-
-Norm of tangent vector `v` at point `x` from manifold `M`.
-"""
-norm(M::Manifold, x, v) = sqrt(real(inner(M, x, v, v)))
-
-"""
-    distance(M::Manifold, x, y)
-
-Shortest distance between the points `x` and `y` on manifold `M`.
-"""
-distance(M::Manifold, x, y) = norm(M, x, log(M, x, y))
-
-"""
-    angle(M::Manifold, x, v, w)
-
-Angle between tangent vectors `v` and `w` at point `x` from manifold `M`.
-"""
-angle(M::Manifold, x, v, w) = acos(real(inner(M, x, v, w)) / norm(M, x, v) / norm(M, x, w))
-
-"""
-    exp!(M::Manifold, y, x, v, t::Real = 1)
-
-Exponential map of tangent vector `t*v` at point `x` from manifold `M`. Result is saved to
-`y`.
-"""
-function exp!(M::Manifold, y, x, v)
-    error("exp! not implemented on a $(typeof(M)) for input point $(x) and tangent vector $(v).")
-end
-exp!(M::Manifold, y, x, v, t::Real) = exp!(M, y, x, t * v)
-
-"""
-    exp(M::Manifold, x, v, t::Real = 1)
-    exp(M::Manifold, x, v, T::AbstractVector) -> AbstractVector
-
-Exponential map of tangent vector `t*v` at point `x` from manifold `M`. `t` may be a scalar
-or elements of vector `T`.
-"""
-function exp(M::Manifold, x, v)
-    y = allocate_result(M, exp, x, v)
-    exp!(M, y, x, v)
-    return y
-end
-exp(M::Manifold, x, v, t::Real) = exp(M, x, t * v)
-exp(M::Manifold, x, v, T::AbstractVector) = map(geodesic(M, x, v), T)
-
-"""
-    log!(M::Manifold, v, x, y)
-
-Logarithmic map of point `y` at base point `x` on Manifold `M`. Result is saved to `v`.
-"""
-function log!(M::Manifold, v, x, y)
-    error("log! not implemented on $(typeof(M)) for points $(typeof(x)) and $(typeof(y))")
-end
-
-"""
-    log(M::Manifold, x, y)
-
-Logarithmic map of point `y` at base point `x` on Manifold `M`.
-"""
-function log(M::Manifold, x, y)
-    v = allocate_result(M, log, x, y)
-    log!(M, v, x, y)
-    return v
-end
-
-"""
-    geodesic(M::Manifold, x, v) -> Function
-
-Get the geodesic with initial point `x` and velocity `v`. The geodesic is the curve of
-constant velocity that is locally distance-minimizing. This function returns a function of
-time, which may be a `Real` or an `AbstractVector`.
-
-    geodesic(M::Manifold, x, v, t::Real)
-    geodesic(M::Manifold, x, v, T::AbstractVector) -> AbstractVector
-
-Return the point at time `t` or points at times `t` in `T` along the geodesic.
-"""
-geodesic(M::Manifold, x, v) = t -> exp(M, x, v, t)
-geodesic(M::Manifold, x, v, t::Real) = exp(M, x, v, t)
-geodesic(M::Manifold, x, v, T::AbstractVector) = exp(M, x, v, T)
-
-@doc doc"""
-    shortest_geodesic(M::Manifold, x, y) -> Function
-
-Get a [`geodesic`](@ref) $\gamma_x(t)$ whose length is the shortest path between the points
-$x$ and $y$, where $\gamma_x(0)=x$ and $\gamma_x(1)=y$. When there are multiple shortest
-geodesics, there is no guarantee which will be returned.
-
-This function returns a function of time, which may be a `Real` or an `AbstractVector`.
-
-    shortest_geodesic(M::Manifold, x, y, t::Real)
-    shortest_geodesic(M::Manifold, x, y, T::AbstractVector) -> AbstractVector
-
-Return the point at time $t$ or points at times $t$ in $T$ along the shortest geodesic.
-"""
-shortest_geodesic(M::Manifold, x, y) = geodesic(M, x, log(M, x, y))
-shortest_geodesic(M::Manifold, x, y, t::Real) = geodesic(M, x, log(M, x, y), t)
-shortest_geodesic(M::Manifold, x, y, T::AbstractVector) = geodesic(M, x, log(M, x, y), T)
-
-"""
-    AbstractVectorTransportMethod
-
-Abstract type for methods for transporting vectors.
-"""
-abstract type AbstractVectorTransportMethod end
-
-"""
-    ParallelTransport <: AbstractVectorTransportMethod
-
-Specify to use parallel transport as vector transport method within
-[`vector_transport_to`](@ref), [`vector_transport_direction`](@ref), or
-[`vector_transport_along`](@ref).
-"""
-struct ParallelTransport <: AbstractVectorTransportMethod end
-
-"""
-    ProjectionTransport <: AbstractVectorTransportMethod
-
-Specify to use projection onto tangent space as vector transport method within
-[`vector_transport_to`](@ref), [`vector_transport_direction`](@ref), or
-[`vector_transport_along`](@ref). See [`project_tangent`](@ref) for details.
-"""
-struct ProjectionTransport <: AbstractVectorTransportMethod end
-
-"""
-    vector_transport_to!(M::Manifold, vto, x, v, y[, method::AbstractVectorTransportMethod])
-
-Vector transport of vector `v` at point `x` to point `y`. The result is saved to `vto`. By
-default, the `method` is [`ParallelTransport`](@ref).
-"""
-function vector_transport_to!(M::Manifold, vto, x, v, y)
-    return vector_transport_to!(M, vto, x, v, y, ParallelTransport())
-end
-
-"""
-    vector_transport_to!(M::Manifold, vto, x, v, y, method::ProjectionTransport)
-
-Transport a vector `v` in the tangent space at `x` on a [`Manifold`](@ref) `M` by
-interpreting it as an element of the embedding and then projecting it onto the tangent space
-at `y`.
-"""
-function vector_transport_to!(M::Manifold, vto, x, v, y, ::ProjectionTransport)
-    return project_tangent!(M, vto, y, v)
-end
-function vector_transport_to!(
-    M::Manifold,
-    vto,
-    x,
-    v,
-    y,
-    method::AbstractVectorTransportMethod,
-)
-    error("vector_transport_to! not implemented from a point of type $(typeof(x)) to a type $(typeof(y)) on a $(typeof(M)) for a vector of type $(v) and the $(typeof(method)).")
-end
-
-"""
-    vector_transport_to(M::Manifold, x, v, y[, method::AbstractVectorTransportMethod])
-
-Transport a vector `v` at point `x` to point `y` using the `method`, which defaults to
-[`ParallelTransport`](@ref).
-"""
-function vector_transport_to(M::Manifold, x, v, y)
-    return vector_transport_to(M, x, v, y, ParallelTransport())
-end
-function vector_transport_to(M::Manifold, x, v, y, method::AbstractVectorTransportMethod)
-    vto = allocate_result(M, vector_transport_to, v, x, y)
-    vector_transport_to!(M, vto, x, v, y, method)
-    return vto
-end
-
-"""
-    vector_transport_direction!(M::Manifold, vto, x, v, vdir[, method::AbstractVectorTransportMethod])
-
-Transport a vector `v` at point `x` in the direction indicated by the tangent vector `vdir`
-at point `x`. The result is saved to `vto`. By default, [`exp`](@ref) and
-[`vector_transport_to!`](@ref) are used with the `method`, which defaults to
-[`ParallelTransport`](@ref).
-"""
-function vector_transport_direction!(M::Manifold, vto, x, v, vdir)
-    return vector_transport_direction!(M, vto, x, v, vdir, ParallelTransport())
-end
-function vector_transport_direction!(
-    M::Manifold,
-    vto,
-    x,
-    v,
-    vdir,
-    method::AbstractVectorTransportMethod,
-)
-    y = exp(M, x, vdir)
-    return vector_transport_to!(M, vto, x, v, y, method)
-end
-
-"""
-    vector_transport_direction(M::Manifold, x, v, vdir[, method::AbstractVectorTransportMethod])
-
-Transport a vector `v` at point `x` in the direction indicated by the tangent vector `vdir`
-at point `x` using the `method`, which defaults to [`ParallelTransport`](@ref).
-"""
-function vector_transport_direction(M::Manifold, x, v, vdir)
-    return vector_transport_direction(M, x, v, vdir, ParallelTransport())
-end
-function vector_transport_direction(
-    M::Manifold,
-    x,
-    v,
-    vdir,
-    method::AbstractVectorTransportMethod,
-)
-    vto = allocate_result(M, vector_transport_direction, v, x, vdir)
-    vector_transport_direction!(M, vto, x, v, vdir, method)
-    return vto
-end
-
-"""
-    vector_transport_along!(M::Manifold, vto, x, v, c[, method::AbstractVectorTransportMethod])
-
-Transport a vector `v` at point `x` along the curve `c` such that `c(0)` is equal to `x` to
-point `c(1)` using the `method`, which defaults to [`ParallelTransport`](@ref). The result
-is saved to `vto`.
-"""
-function vector_transport_along!(M::Manifold, vto, x, v, c)
-    return vector_transport_along!(M, vto, x, v, c, ParallelTransport())
-end
-function vector_transport_along!(
-    M::Manifold,
-    vto,
-    x,
-    v,
-    c,
-    method::AbstractVectorTransportMethod,
-)
-    error("vector_transport_along! not implemented for manifold $(typeof(M)), vector $(typeof(vto)), point $(typeof(x)), vector $(typeof(v)) along curve $(typeof(c)) with method $(typeof(method)).")
-end
-
-"""
-    vector_transport_along(M::Manifold, x, v, c[, method::AbstractVectorTransportMethod])
-
-Transport a vector `v` at point `x` along the curve `c` such that `c(0)` is equal to `x` to
-point `c(1)`. The default `method` used is [`ParallelTransport`](@ref).
-"""
-function vector_transport_along(M::Manifold, x, v, c)
-    return vector_transport_along(M, x, v, c, ParallelTransport())
-end
-function vector_transport_along(M::Manifold, x, v, c, m::AbstractVectorTransportMethod)
-    vto = allocate_result(M, vector_transport_along, v, x)
-    vector_transport_along!(M, vto, x, v, c, m)
-    return vto
-end
-
-@doc doc"""
-    injectivity_radius(M::Manifold, x)
-
-Distance $d$ such that [`exp(M, x, v)`](@ref exp(::Manifold, ::Any, ::Any)) is injective for
-all tangent vectors shorter than $d$ (i.e. has a left inverse).
-
-    injectivity_radius(M::Manifold)
-
-Infimum of the injectivity radius of all manifold points.
-
-    injectivity_radius(M::Manifold[, x], method::AbstractRetractionMethod)
-
-Distance $d$ such that
-[`retract(M, x, v, method)`](@ref retract(::Manifold, ::Any, ::Any, ::AbstractRetractionMethod))
-is injective for all tangent vectors shorter than $d$ (i.e. has a left inverse) for point
-$x$ if provided or all manifold points otherwise.
-"""
-function injectivity_radius(M::Manifold)
-    error("injectivity_radius not implemented for manifold $(typeof(M)).")
-end
-injectivity_radius(M::Manifold, x) = injectivity_radius(M)
-injectivity_radius(M::Manifold, x, method::AbstractRetractionMethod) = injectivity_radius(M, method)
-function injectivity_radius(M::Manifold, method::AbstractRetractionMethod)
-    error("injectivity_radius not implemented for manifold $(typeof(M)) and retraction method $(typeof(method)).")
-end
-injectivity_radius(M::Manifold, x, ::ExponentialRetraction) = injectivity_radius(M, x)
-injectivity_radius(M::Manifold, ::ExponentialRetraction) = injectivity_radius(M)
-
-"""
-    zero_tangent_vector(M::Manifold, x)
-
-Vector `v` such that retracting `v` to manifold `M` at `x` produces `x`.
-"""
-function zero_tangent_vector(M::Manifold, x)
-    v = allocate_result(M, zero_tangent_vector, x)
-    zero_tangent_vector!(M, v, x)
-    return v
-end
-
-"""
-    zero_tangent_vector!(M::Manifold, v, x)
-
-Save to `v` a vector such that retracting `v` to manifold `M` at `x` produces `x`.
-"""
-zero_tangent_vector!(M::Manifold, v, x) = log!(M, v, x, x)
 
 """
     allocate(a)
@@ -617,8 +140,333 @@ allocate(a, T::Type, dims::Int...) = similar(a, T, dims...)
 allocate(a, T::Type, dims::Tuple) = similar(a, T, dims)
 allocate(a::AbstractArray{<:AbstractArray}) = map(allocate, a)
 allocate(a::AbstractArray{<:AbstractArray}, T::Type) = map(t -> allocate(t, T), a)
-allocate(a::NTuple{N,AbstractArray} where N) = map(allocate, a)
-allocate(a::NTuple{N,AbstractArray} where N, T::Type) = map(t -> allocate(t, T), a)
+allocate(a::NTuple{N,AbstractArray} where {N}) = map(allocate, a)
+allocate(a::NTuple{N,AbstractArray} where {N}, T::Type) = map(t -> allocate(t, T), a)
+
+"""
+    allocate_result(M::Manifold, f, x...)
+
+Allocate an array for the result of function `f` on [`Manifold`](@ref) `M` and arguments
+`x...` for implementing the non-modifying operation using the modifying operation.
+
+Usefulness of passing a function is demonstrated by methods that allocate results of musical
+isomorphisms.
+"""
+function allocate_result(M::Manifold, f, x...)
+    T = allocate_result_type(M, f, x)
+    return allocate(x[1], T)
+end
+
+"""
+    allocate_result_type(M::Manifold, f, args::NTuple{N,Any}) where N
+
+Return type of element of the array that will represent the result of function `f` and the
+[`Manifold`](@ref) `M` on given arguments `args` (passed as a tuple).
+"""
+function allocate_result_type(M::Manifold, f, args::NTuple{N,Any}) where {N}
+    T = typeof(reduce(+, one(number_eltype(eti)) for eti ∈ args))
+    return T
+end
+
+"""
+    angle(M::Manifold, p, X, Y)
+
+Compute the angle between tangent vectors `X` and `Y` at point `p` from the
+[`Manifold`](@ref) `M` with respect to the inner product from [`inner`](@ref).
+"""
+angle(M::Manifold, p, X, Y) = acos(real(inner(M, p, X, Y)) / norm(M, p, X) / norm(M, p, Y))
+
+"""
+    base_manifold(M::Manifold, depth = -1)
+
+Return the internally stored [`Manifold`](@ref) for decorated manifold `M` and the base
+manifold for vector bundles or power manifolds. The optional parameter `depth` can be used
+to remove only the first `depth` many decorators and return the [`Manifold`](@ref) from that
+level, whether its decorated or not. any negative value deactivates this depth limit.
+"""
+base_manifold(M::Manifold, depth=-1) = base_manifold(M, is_decorator_manifold(M),depth)
+function base_manifold(M::Manifold, ::Val{true}, depth=-1)
+    # if we reach zero, return M, otherwise reduce positive level
+    # and leave negative values unchanged to avoid the (really unprobable) underrun
+    return (depth != 0) ? base_manifold(M.manifold, (depth > 0) ? depth-1 : depth) : M
+end
+base_manifold(M::Manifold, ::Val{false}, depth=-1) = M
+
+"""
+    check_manifold_point(M::Manifold, p; kwargs...) -> Union{Nothing,String}
+
+Return `nothing` when `p` is a point on the [`Manifold`](@ref) `M`. Otherwise, return an
+error with description why the point does not belong to manifold `M`.
+
+By default, `check_manifold_point` returns `nothing`, i.e. if no checks are implemented, the
+assumption is to be optimistic for a point not deriving from the [`MPoint`](@ref) type.
+"""
+check_manifold_point(M::Manifold, p; kwargs...) = nothing
+function check_manifold_point(M::Manifold, p::MPoint; kwargs...)
+    error(
+        "check_manifold_point not implemented for manifold $(typeof(M)) and point $(typeof(p))."
+    )
+end
+
+"""
+    check_tangent_vector(M::Manifold, p, X; kwargs...) -> Union{Nothing,String}
+
+Check whether `X` is a valid tangent vector in the tangent space of `p` on the
+[`Manifold`](@ref) `M`. An implementation should first call [`check_manifold_point(M, p;
+kwargs...)`](@ref) and then validate `X`. If it is not a tangent vector, an error string
+should be returned.
+
+By default, `check_tangent_vector` returns `nothing`, i.e. if no checks are implemented, the
+assumption is to be optimistic for tangent vectors not deriving from the [`TVector`](@ref)
+type.
+"""
+check_tangent_vector(M::Manifold, p, X; kwargs...) = nothing
+function check_tangent_vector(M::Manifold, p::MPoint, X::TVector; kwargs...)
+    error("check_tangent_vector not implemented for manifold $(typeof(M)), point $(typeof(p)) and vector $(typeof(X)).")
+end
+
+"""
+    distance(M::Manifold, p, q)
+
+Shortest distance between the points `p` and `q` on the [`Manifold`](@ref) `M`.
+"""
+distance(M::Manifold, p, q) = norm(M, p, log(M, p, q))
+
+"""
+    exp(M::Manifold, p, X)
+    exp(M::Manifold, p, X, t::Real = 1)
+    exp(M::Manifold, p, X, T::AbstractVector) -> AbstractVector
+
+Compute the exponential map of tangent vector `X`, optionally scaled by `t`,  at point `p`
+from manifold the [`Manifold`](@ref) `M`.
+"""
+function exp(M::Manifold, p, X)
+    q = allocate_result(M, exp, p, X)
+    exp!(M, q, p, X)
+    return q
+end
+exp(M::Manifold, p, X, t::Real) = exp(M, p, t * X)
+exp(M::Manifold, p, X, T::AbstractVector) = map(t -> exp(M, p, X, t), T)
+
+"""
+    exp!(M::Manifold, q, p, X)
+    exp!(M::Manifold, q, p, X, t::Real = 1)
+
+Compute the exponential map of tangent vector `X`, optionally scaled by `t`,  at point `p`
+from manifold the [`Manifold`](@ref) `M`.
+The result is saved to `y`.
+"""
+function exp!(M::Manifold, q, p, X)
+    error("exp! not implemented on a $(typeof(M)) for input point $(p) and tangent vector $(X).")
+end
+exp!(M::Manifold, q, p, X, t::Real) = exp!(M, q, p, t * X)
+
+"""
+    geodesic(M::Manifold, p, X) -> Function
+
+Get the geodesic with initial point `p` and velocity `X` on the [`Manifold`](@ref) `M`.
+ The geodesic is the curve of constant velocity that is locally distance-minimizing.
+ This function returns a function of (time) `t`.
+
+    geodesic(M::Manifold, x, v, t::Real)
+    geodesic(M::Manifold, x, v, T::AbstractVector) -> AbstractVector
+
+Return the point at time `t` or points at times `t` in `T` along the geodesic.
+"""
+geodesic(M::Manifold, p, X) = t -> exp(M, p, X, t)
+geodesic(M::Manifold, p, X, t::Real) = exp(M, p, X, t)
+geodesic(M::Manifold, p, X, T::AbstractVector) = exp(M, p, X, T)
+
+@doc doc"""
+    injectivity_radius(M::Manifold, p)
+
+Return the distance $d$ such that [`exp(M, p, X)`](@ref exp(::Manifold, ::Any, ::Any)) is
+injective for all tangent vectors shorter than $d$ (i.e. has an inverse).
+
+    injectivity_radius(M::Manifold)
+
+Infimum of the injectivity radius of all manifold points.
+
+    injectivity_radius(M::Manifold[, x], method::AbstractRetractionMethod)
+    injectivity_radius(M::Manifold, x, method::AbstractRetractionMethod)
+
+Distance $d$ such that
+[`retract(M, p, X, method)`](@ref retract(::Manifold, ::Any, ::Any, ::AbstractRetractionMethod))
+is injective for all tangent vectors shorter than $d$ (i.e. has an inverse) for point `p`
+if provided or all manifold points otherwise.
+"""
+function injectivity_radius(M::Manifold)
+    error("injectivity_radius not implemented for manifold $(typeof(M)).")
+end
+injectivity_radius(M::Manifold, p) = injectivity_radius(M)
+injectivity_radius(M::Manifold, p, method::AbstractRetractionMethod) =
+    injectivity_radius(M, method)
+function injectivity_radius(M::Manifold, method::AbstractRetractionMethod)
+    error("injectivity_radius not implemented for manifold $(typeof(M)) and retraction method $(typeof(method)).")
+end
+injectivity_radius(M::Manifold, p, ::ExponentialRetraction) = injectivity_radius(M, p)
+injectivity_radius(M::Manifold, ::ExponentialRetraction) = injectivity_radius(M)
+
+"""
+    inner(M::Manifold, p, X, Y)
+
+Compute the inner product of tangent vectors `X` and `Y` at point `p` from the
+[`Manifold`](@ref) `M`.
+"""
+function inner(M::Manifold, p, X, Y)
+    error(
+        "inner not implemented on a $(typeof(M)) for input point $(typeof(p)) and tangent vectors $(typeof(X)) and $(typeof(Y))."
+    )
+end
+
+"""
+    inverse_retract!(M::Manifold, X, p, q[, method::AbstractInverseRetractionMethod])
+
+Compute the inverse retraction, a cheaper, approximate version of the
+[`log`](@ref)arithmic map), of points `p` and `q` on the [`Manifold`](@ref) `M`.
+Result is saved to `X`.
+
+Inverse retraction method can be specified by the last argument, defaulting to
+[`LogarithmicInverseRetraction`](@ref). See the documentation of respective manifolds for
+available methods.
+"""
+function inverse_retract!(M::Manifold, X, p, q)
+    return inverse_retract!(M, X, p, q, LogarithmicInverseRetraction())
+end
+function inverse_retract!(M::Manifold, X, p, q, method::LogarithmicInverseRetraction)
+    return log!(M, X, p, q)
+end
+
+"""
+    inverse_retract(M::Manifold, x, y)
+    inverse_retract(M::Manifold, x, y, method::AbstractInverseRetractionMethod
+
+Compute the inverse retraction, a cheaper, approximate version of the
+[`log`](@ref)arithmic map), of points `p` and `q` on the [`Manifold`](@ref) `M`.
+
+Inverse retraction method can be specified by the last argument, defaulting to
+[`LogarithmicInverseRetraction`](@ref). See the documentation of respective manifolds for
+available methods.
+"""
+function inverse_retract(M::Manifold, p, q)
+    X = allocate_result(M, inverse_retract, p, q)
+    inverse_retract!(M, X, p, q)
+    return X
+end
+function inverse_retract(M::Manifold, p, q, method::AbstractInverseRetractionMethod)
+    X = allocate_result(M, inverse_retract, p, q)
+    inverse_retract!(M, X, p, q, method)
+    return X
+end
+
+"""
+    isapprox(M::Manifold, p, q; kwargs...)
+
+Check if points `p` and `q` from [`Manifold`](@ref) `M` are approximately equal.
+
+Keyword arguments can be used to specify tolerances.
+"""
+isapprox(M::Manifold, x, y; kwargs...) = isapprox(x, y; kwargs...)
+
+"""
+    isapprox(M::Manifold, p, X, Y; kwargs...)
+
+Check if vectors `X` and `Y` tangent at `p` from [`Manifold`](@ref) `M` are approximately
+equal.
+
+Keyword arguments can be used to specify tolerances.
+"""
+isapprox(M::Manifold, x, v, w; kwargs...) = isapprox(v, w; kwargs...)
+
+"""
+    is_decorator_manifold(M::Manifold)
+
+Indicate whether a [`Manifold`](@ref) `M` is a decorator manifold, i.e. whether it
+encapsulates a manifold with additional features and stores internally the original manifold
+instance. An example is the [`ArrayManifold`](@ref).
+
+Certain functions are just calling themselves on the internal manifold and hence do not need
+to be reimplemented for decorators again, for example [`manifold_dimension`](@ref) and
+especially [`base_manifold`](@ref).
+
+It is assumed that the undecorated (base) manifold is stored in `M.manifold`. Alternatively,
+overload [`base_manifold`](@ref).
+"""
+is_decorator_manifold(::Manifold) = Val(false)
+
+"""
+    is_manifold_point(M::Manifold, p, throw_error = false; kwargs...)
+
+Return whether `p` is a valid point on the [`Manifold`](@ref) `M`.
+
+If `throw_error` is `false`, the function returns either `true` or `false`. If `throw_error`
+is `true`, the function either returns `true` or throws an error. By default the function
+calls [`check_manifold_point(M, p; kwargs...)`](@ref) and checks whether the returned value
+is `nothing` or an error.
+"""
+function is_manifold_point(M::Manifold, p, throw_error = false; kwargs...)
+    mpe = check_manifold_point(M, p; kwargs...)
+    mpe === nothing && return true
+    return throw_error ? throw(mpe) : false
+end
+
+"""
+    is_tangent_vector(M::Manifold, p, X, throw_error = false; kwargs...)
+
+Return whether `X` is a valid tangent vector at point `p` on the [`Manifold`](@ref) `M`.
+Returns either `true` or `false`.
+
+If `throw_error` is `false`, the function returns either `true` or `false`. If `throw_error`
+is `true`, the function either returns `true` or throws an error. By default the function
+calls [`check_tangent_vector(M, p, X; kwargs...)`](@ref) and checks whether the returned
+value is `nothing` or an error.
+"""
+function is_tangent_vector(M::Manifold, p, X, throw_error = false; kwargs...)
+    mtve = check_tangent_vector(M, p, X; kwargs...)
+    mtve === nothing && return true
+    return throw_error ? throw(mtve) : false
+end
+
+"""
+    log(M::Manifold, p, q)
+
+Compute the logarithmic map of point `q` at base point `p` on the [`Manifold`](@ref) `M`.
+"""
+function log(M::Manifold, p, q)
+    X = allocate_result(M, log, p, q)
+    log!(M, X, p, q)
+    return X
+end
+
+"""
+    log!(M::Manifold, X, p, q)
+
+Compute the logarithmic map of point `q` at base point `p` on the [`Manifold`](@ref) `M`.
+THe result is saved to `X`.
+"""
+function log!(M::Manifold, X, p, q)
+    error("log! not implemented on $(typeof(M)) for points $(typeof(p)) and $(typeof(q))")
+end
+
+@doc doc"""
+    manifold_dimension(M::Manifold)
+
+The dimension $n=\dim_{\mathcal M}$ of real space $\mathbb R^n$ to which the neighborhood of
+each point of the [`Manifold`](@ref) `M` is homeomorphic.
+"""
+manifold_dimension(M::Manifold) = manifold_dimension(M, is_decorator_manifold(M))
+manifold_dimension(M::Manifold, ::Val{true}) = manifold_dimension(base_manifold(M))
+function manifold_dimension(M::Manifold, ::Val{false})
+    error("manifold_dimension not implemented for manifold $(typeof(M)).")
+end
+
+"""
+    norm(M::Manifold, p, X)
+
+Compute the norm of tangent vector `X` at point `p` from a [`Manifold`](@ref) `M`.
+By default this is computed using [`inner`](@ref).
+"""
+norm(M::Manifold, p, X) = sqrt(real(inner(M, p, X, X)))
 
 """
     number_eltype(x)
@@ -637,149 +485,336 @@ function number_eltype(x::Tuple)
 end
 
 """
-    allocate_result_type(M::Manifold, f, args::NTuple{N,Any}) where N
+    project_point(M::Manifold, p)
 
-Return type of element of the array that will represent the result of function `f` for
-manifold `M` on given arguments `args` (passed as a tuple).
+Project point `p`from the ambient space onto the [`Manifold`](@ref) `M`.
+The function works only for selected embedded manifolds and is *not* required to return the
+closest point.
 """
-function allocate_result_type(M::Manifold, f, args::NTuple{N,Any}) where {N}
-    T = typeof(reduce(+, one(number_eltype(eti)) for eti ∈ args))
-    return T
+function project_point(M::Manifold, p)
+    q = allocate_result(M, project_point, p)
+    project_point!(M, q, p)
+    return q
 end
 
 """
-    allocate_result(M::Manifold, f, x...)
+    project_point!(M::Manifold, q, p)
 
-Allocate an array for the result of function `f` on manifold `M` and arguments `x...` for
-implementing the non-modifying operation using the modifying operation.
-
-Usefulness of passing a function is demonstrated by methods that allocate results of musical
-isomorphisms.
+Project point `p` from the ambient space onto the [`Manifold`](@ref) `M`. The point `q` is
+overwritten by the projection. The function works only for selected embedded manifolds and
+is *not* required to return the closest point.
 """
-function allocate_result(M::Manifold, f, x...)
-    T = allocate_result_type(M, f, x)
-    return allocate(x[1], T)
+function project_point!(M::Manifold, q, p)
+    error("project_point! not implemented for a $(typeof(M)) and points $(typeof(q)) and $(typeof(p)).")
 end
 
 """
-    check_manifold_point(M::Manifold, x; kwargs...) -> Union{Nothing,String}
+    project_tangent(M::Manifold, p, X)
 
-Return `nothing` when `x` is a point on manifold `M`. Otherwise, return a string with a
-description why the point does not belong to manifold `M`.
+Project ambient space representation of a vector `X` to a tangent vector at point `p` on
+the [`Manifold`](@ref) `M`.
 
-By default, `check_manifold_point` returns `nothing`, i.e. if no checks are implemented, the
-assumption is to be optimistic for a point not deriving from the [`MPoint`](@ref) type.
+The function works only for selected embedded manifolds and is *not* required to return the
+closest vector.
 """
-check_manifold_point(M::Manifold, x; kwargs...) = nothing
-function check_manifold_point(M::Manifold, x::MPoint; kwargs...)
-    error("check_manifold_point not implemented for manifold $(typeof(M)) and point $(typeof(x)).")
+function project_tangent(M::Manifold, p, X)
+    vt = allocate_result(M, project_tangent, X, p)
+    project_tangent!(M, vt, p, X)
+    return vt
 end
 
 """
-    is_manifold_point(M::Manifold, x, throw_error = false; kwargs...)
+    project_tangent!(M::Manifold, Y, p, X)
 
-Return whether `x` is a valid point on the [`Manifold`](@ref) `M`.
+Project ambient space representation of a vector `X` to a tangent vector at point `p` on
+the [`Manifold`](@ref) `M`. The result is saved in vector `Y`.
 
-If `throw_error` is `false`, the function returns either `true` or `false`. If `throw_error`
-is `true`, the function either returns `true` or throws an error. By default the function
-calls [`check_manifold_point(M, x; kwargs...)`](@ref) and checks whether the returned value
-is `nothing` or an error.
+The function works only for selected embedded manifolds and is *not* required to return the
+closest vector.
 """
-function is_manifold_point(M::Manifold, x, throw_error = false; kwargs...)
-    mpe = check_manifold_point(M, x; kwargs...)
-    mpe === nothing && return true
-    return throw_error ? throw(mpe) : false
+function project_tangent!(M::Manifold, Y, p, X)
+    error(
+        "project_tangent! not implemented for a $(typeof(M)) and point $(typeof(p)) with input $(typeof(X))."
+    )
+end
+
+@doc doc"""
+    representation_size(M::Manifold)
+
+The size of an array representing a point on [`Manifold`](@ref) `M`.
+"""
+representation_size(M::Manifold) = representation_size(M, is_decorator_manifold(M))
+representation_size(M::Manifold, ::Val{true}) = representation_size(base_manifold(M))
+function representation_size(M::Manifold, ::Val{false})
+    error("representation_size not implemented for manifold $(typeof(M)).")
 end
 
 """
-    check_tangent_vector(M::Manifold, x, v; kwargs...) -> Union{Nothing,String}
+    retract(M::Manifold, p, X)
+    retract(M::Manifold, p, X, t::Real=1)
+    retract(M::Manifold, p, X, method::AbstractRetractionMethod)
+    retract(M::Manifold, p, X, t::Real=1, method::AbstractRetractionMethod)
 
-Check whether `v` is a valid tangent vector in the tangent plane of `x` on the
-[`Manifold`](@ref) `M`. An implementation should first call [`check_manifold_point(M, x;
-kwargs...)`](@ref) and then validate `v`. If it is not a tangent vector, an error string
-should be returned.
+Compute a retraction, a cheaper, approximate version of the [`exp`](@ref)onential map,
+from `p` into direction `X`, scaled by `t`, on the [`Manifold`](@ref) `M`.
 
-By default, `check_tangent_vector` returns `nothing`, i.e. if no checks are implemented, the
-assumption is to be optimistic for tangent vectors not deriving from the [`TVector`](@ref)
-type.
+Retraction method can be specified by the last argument, defaulting to
+[`ExponentialRetraction`](@ref). See the documentation of respective manifolds for available
+methods.
 """
-check_tangent_vector(M::Manifold, x, v; kwargs...) = nothing
-function check_tangent_vector(M::Manifold, x::MPoint, v::TVector; kwargs...)
-    error("check_tangent_vector not implemented for manifold $(typeof(M)), point $(typeof(x)) and vector $(typeof(v)).")
+function retract(M::Manifold, p, X)
+    q = allocate_result(M, retract, p, X)
+    retract!(M, q, p, X)
+    return q
+end
+retract(M::Manifold, p, X, t::Real) = retract(M, p, t * X)
+function retract(M::Manifold, p, X, method::AbstractRetractionMethod)
+    q = allocate_result(M, retract, p, X)
+    retract!(M, q, p, X, method)
+    return q
+end
+function retract(M::Manifold, p, X, t::Real, method::AbstractRetractionMethod)
+    return retract(M, p, t * X, method)
 end
 
 """
-    is_tangent_vector(M::Manifold, x, v, throw_error = false; kwargs...)
+    retract!(M::Manifold, q, p, X)
+    retract!(M::Manifold, q, p, X, t::Real=1)
+    retract!(M::Manifold, q, p, X, method::AbstractRetractionMethod)
+    retract!(M::Manifold, q, p, X, t::Real=1, method::AbstractRetractionMethod)
 
-Return whether `v` is a valid tangent vector at point `x` on the [`Manifold`](@ref) `M`.
-Returns either `true` or `false`.
+Compute a retraction, a cheaper, approximate version of the [`exp`](@ref)onential map,
+from `p` into direction `X`, scaled by `t`, on the [`Manifold`](@ref) manifold `M`.
+Result is saved to `y`.
 
-The default is to return `true`, i.e. if no checks are implemented, the assumption is to be
-optimistic.
+Retraction method can be specified by the last argument, defaulting to
+[`ExponentialRetraction`](@ref). See the documentation of respective manifolds for available
+methods.
 """
-function is_tangent_vector(M::Manifold, x, v, throw_error = false; kwargs...)
-    mtve = check_tangent_vector(M, x, v; kwargs...)
-    mtve === nothing && return true
-    return throw_error ? throw(mtve) : false
+retract!(M::Manifold, q, p, X) = retract!(M, q, p, X, ExponentialRetraction())
+retract!(M::Manifold, q, p, X, t::Real) = retract!(M, q, p, t * X)
+retract!(M::Manifold, q, p, X, method::ExponentialRetraction) = exp!(M, q, p, X)
+function retract!(M::Manifold, q, p, X, t::Real, method::AbstractRetractionMethod)
+    return retract!(M, q, p, t * X, method)
+end
+
+@doc doc"""
+    shortest_geodesic(M::Manifold, p, q) -> Function
+
+Get a [`geodesic`](@ref) $\gamma_{p,q}(t)$ whose length is the shortest path between the
+points `p`and `q`, where $\gamma_{p,q}(0)=p$ and $\gamma_{p,q}(1)=q$. When there are
+multiple shortest geodesics, there is no guarantee which will be returned.
+
+This function returns a function of time, which may be a `Real` or an `AbstractVector`.
+
+    shortest_geodesic(M::Manifold, p, q, t::Real)
+    shortest_geodesic(M::Manifold, p, q, T::AbstractVector) -> AbstractVector
+
+Return the point at time `t` or points at times `t` in `T` along the shortest geodesic.
+"""
+shortest_geodesic(M::Manifold, p, q) = geodesic(M, p, log(M, p, q))
+shortest_geodesic(M::Manifold, p, q, t::Real) = geodesic(M, p, log(M, p, q), t)
+shortest_geodesic(M::Manifold, p, q, T::AbstractVector) = geodesic(M, p, log(M, p, q), T)
+
+"""
+    vector_transport_along(M::Manifold, p, X, c)
+    vector_transport_along(M::Manifold, p, X, c, method::AbstractVectorTransportMethod)
+
+Transport a vector `X` from a point `p` along the curve `c` such that `c(0)` is equal to `x`
+to the point `c(1)` using the `method`, which defaults to [`ParallelTransport`](@ref).
+"""
+function vector_transport_along(M::Manifold, p, X, c)
+    return vector_transport_along(M, p, X, c, ParallelTransport())
+end
+function vector_transport_along(M::Manifold, p, X, c, m::AbstractVectorTransportMethod)
+    Y = allocate_result(M, vector_transport_along, X, p)
+    vector_transport_along!(M, Y, p, X, c, m)
+    return Y
 end
 
 """
-    AbstractEstimationMethod
+    vector_transport_along!(M::Manifold, Y, p, X, c)
+    vector_transport_along!(M::Manifold, Y, p, X, c, method::AbstractVectorTransportMethod)
 
-Abstract type for defining statistical estimation methods.
+Transport a vector `X` from a point `p` along the curve `c` such that `c(0)` is equal to `x`
+to the point `c(1)` using the `method`, which defaults to [`ParallelTransport`](@ref).
+The result is saved to `Y`.
 """
-abstract type AbstractEstimationMethod end
+function vector_transport_along!(M::Manifold, Y, p, X, c)
+    return vector_transport_along!(M, Y, p, X, c, ParallelTransport())
+end
+function vector_transport_along!(
+    M::Manifold,
+    Y,
+    p,
+    X,
+    c,
+    method::AbstractVectorTransportMethod,
+)
+    error("vector_transport_along! not implemented for manifold $(typeof(M)), vector $(typeof(Y)), point $(typeof(p)), vector $(typeof(X)) along curve $(typeof(c)) with method $(typeof(method)).")
+end
+
+
+"""
+    vector_transport_direction(M::Manifold, p, X, d)
+    vector_transport_direction(M::Manifold, p, X, d, method::AbstractVectorTransportMethod)
+
+Transport a vector `X` from a point `p` in the direction indicated by the tangent vector `d`
+at point `p`. By default, [`exp`](@ref) and [`vector_transport_to!`](@ref) are used with
+the `method`, which defaults to [`ParallelTransport`](@ref).
+"""
+function vector_transport_direction(M::Manifold, p, X, d)
+    return vector_transport_direction(M, p, X, d, ParallelTransport())
+end
+function vector_transport_direction(
+    M::Manifold,
+    p,
+    X,
+    d,
+    method::AbstractVectorTransportMethod,
+)
+    Y = allocate_result(M, vector_transport_direction, X, p, d)
+    vector_transport_direction!(M, Y, p, X, d, method)
+    return Y
+end
+
+"""
+    vector_transport_direction!(M::Manifold, Y, p, X, d)
+    vector_transport_direction!(M::Manifold, Y, p, X, d, method::AbstractVectorTransportMethod)
+
+Transport a vector `X` from a point `p` in the direction indicated by the tangent vector `d`
+at point `p`. The result is saved to `Y`. By default, [`exp`](@ref) and
+[`vector_transport_to!`](@ref) are used with the `method`, which defaults to
+[`ParallelTransport`](@ref).
+"""
+function vector_transport_direction!(M::Manifold, Y, p, X, d)
+    return vector_transport_direction!(M, Y, p, X, d, ParallelTransport())
+end
+function vector_transport_direction!(
+    M::Manifold,
+    Y,
+    p,
+    X,
+    d,
+    method::AbstractVectorTransportMethod,
+)
+    y = exp(M, p, d)
+    return vector_transport_to!(M, Y, p, X, y, method)
+end
+
+"""
+    vector_transport_to(M::Manifold, p, X, q)
+    vector_transport_to(M::Manifold, p, X, q, method::AbstractVectorTransportMethod)
+
+Compute the vector transport of vector `X` at point `p` to point `q`.
+By default, the [`AbstractVectorTransportMethod`](@ref) `method` is
+[`ParallelTransport`](@ref).
+"""
+function vector_transport_to(M::Manifold, p, X, q)
+    return vector_transport_to(M, p, X, q, ParallelTransport())
+end
+function vector_transport_to(M::Manifold, p, X, q, method::AbstractVectorTransportMethod)
+    Y = allocate_result(M, vector_transport_to, X, p, q)
+    vector_transport_to!(M, Y, p, X, q, method)
+    return Y
+end
+
+"""
+    vector_transport_to!(M::Manifold, Y, p, X, q)
+    vector_transport_to!(M::Manifold, Y, p, X, q, method::AbstractVectorTransportMethod)
+
+Compute the vector transport of vector `X` at point `p` to point `q`.
+The result is saved to `Y`. By default, the [`AbstractVectorTransportMethod`](@ref) `method`
+is [`ParallelTransport`](@ref).
+"""
+function vector_transport_to!(M::Manifold, Y, p, q, X)
+    return vector_transport_to!(M, Y, p, q, X, ParallelTransport())
+end
+"""
+    vector_transport_to!(M::Manifold, Y, p, X, q, method::ProjectionTransport)
+
+Transport a vector `X` from the tangent space at `p` on a [`Manifold`](@ref) `M` by
+interpreting it as an element of the embedding and then projecting it onto the tangent space
+at `q`. This method requires [`project_tangent`](@ref).
+"""
+function vector_transport_to!(M::Manifold, Y, p, X, q, ::ProjectionTransport)
+    return project_tangent!(M, Y, q, X)
+end
+function vector_transport_to!(
+    M::Manifold,
+    Y,
+    p,
+    X,
+    q,
+    method::AbstractVectorTransportMethod,
+)
+    error("vector_transport_to! not implemented from a point of type $(typeof(p)) to a type $(typeof(q)) on a $(typeof(M)) for a vector of type $(X) and the $(typeof(method)).")
+end
+
+"""
+    zero_tangent_vector!(M::Manifold, X, p)
+
+Save to `X` a vector such that retracting `X` to the [`Manifold`](@ref) `M` at `p`
+produces `p`.
+"""
+zero_tangent_vector!(M::Manifold, X, p) = log!(M, X, p, p)
+
+"""
+    zero_tangent_vector(M::Manifold, p)
+
+Return the tangent vector from the tangent space at `x` on the [`Manifold`](@ref) `M`, that
+represents the zero vector, i.e. such that a retraction at `x` produces `x`.
+"""
+function zero_tangent_vector(M::Manifold, p)
+    X = allocate_result(M, zero_tangent_vector, p)
+    zero_tangent_vector!(M, X, p)
+    return X
+end
 
 include("ArrayManifold.jl")
 include("DefaultManifold.jl")
 
 export Manifold,
-       MPoint,
-       TVector,
-       CoTVector,
-       ArrayManifold,
-       ArrayMPoint,
-       ArrayTVector,
-       ArrayCoTVector
+    MPoint, TVector, CoTVector, ArrayManifold, ArrayMPoint, ArrayTVector, ArrayCoTVector
 
 export ParallelTransport, ProjectionTransport
 
 export allocate,
-       base_manifold,
-       check_manifold_point,
-       check_tangent_vector,
-       distance,
-       exp,
-       exp!,
-       geodesic,
-       shortest_geodesic,
-       injectivity_radius,
-       inner,
-       inverse_retract,
-       inverse_retract!,
-       isapprox,
-       is_manifold_point,
-       is_tangent_vector,
-       is_decorator_manifold,
-       log,
-       log!,
-       manifold_dimension,
-       norm,
-       number_eltype,
-       project_point,
-       project_point!,
-       project_tangent,
-       project_tangent!,
-       representation_size,
-       retract,
-       retract!,
-       vector_transport_along,
-       vector_transport_along!,
-       vector_transport_direction,
-       vector_transport_direction!,
-       vector_transport_to,
-       vector_transport_to!,
-       zero_tangent_vector,
-       zero_tangent_vector!
+    base_manifold,
+    check_manifold_point,
+    check_tangent_vector,
+    distance,
+    exp,
+    exp!,
+    geodesic,
+    shortest_geodesic,
+    injectivity_radius,
+    inner,
+    inverse_retract,
+    inverse_retract!,
+    isapprox,
+    is_manifold_point,
+    is_tangent_vector,
+    is_decorator_manifold,
+    log,
+    log!,
+    manifold_dimension,
+    norm,
+    number_eltype,
+    project_point,
+    project_point!,
+    project_tangent,
+    project_tangent!,
+    representation_size,
+    retract,
+    retract!,
+    vector_transport_along,
+    vector_transport_along!,
+    vector_transport_direction,
+    vector_transport_direction!,
+    vector_transport_to,
+    vector_transport_to!,
+    zero_tangent_vector,
+    zero_tangent_vector!
 
 end # module

--- a/test/allocation.jl
+++ b/test/allocation.jl
@@ -15,8 +15,8 @@ end
     M = AllocManifold()
     v = exp(M, a, b)
     @test v ≈ [[3.0], [5.0], [0.0]]
-    @test allocate(([1.0], [2.0])) isa Tuple{Vector{Float64}, Vector{Float64}}
-    @test allocate(([1.0], [2.0]), Int) isa Tuple{Vector{Int}, Vector{Int}}
+    @test allocate(([1.0], [2.0])) isa Tuple{Vector{Float64},Vector{Float64}}
+    @test allocate(([1.0], [2.0]), Int) isa Tuple{Vector{Int},Vector{Int}}
     @test allocate([[1.0], [2.0]]) isa Vector{Vector{Float64}}
     @test allocate([[1.0], [2.0]], Int) isa Vector{Vector{Int}}
 

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -4,25 +4,32 @@ using Test
 
 struct CustomArrayManifoldRetraction <: ManifoldsBase.AbstractRetractionMethod end
 
-ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomArrayManifoldRetraction) = 10.0
-ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArrayManifoldRetraction) = 11.0
+ManifoldsBase.injectivity_radius(
+    ::ManifoldsBase.DefaultManifold,
+    ::CustomArrayManifoldRetraction,
+) = 10.0
+ManifoldsBase.injectivity_radius(
+    ::ManifoldsBase.DefaultManifold,
+    x,
+    ::CustomArrayManifoldRetraction,
+) = 11.0
 
 @testset "Array manifold" begin
     M = ManifoldsBase.DefaultManifold(3)
     A = ArrayManifold(M)
-    x = [1., 0., 0.]
-    y = 1/sqrt(2)*[1., 1., 0.]
-    z = [0., 1., 0.]
-    v = log(M,x,y)
+    x = [1.0, 0.0, 0.0]
+    y = 1 / sqrt(2) * [1.0, 1.0, 0.0]
+    z = [0.0, 1.0, 0.0]
+    v = log(M, x, y)
     x2 = ArrayMPoint(x)
     y2 = ArrayMPoint(y)
-    v2 = log(A,x,y) # auto convert
-    y2 = exp(A,x,v2)
-    w = log(M,x,z)
-    w2 = log(A,x,z; atol=10^(-15))
+    v2 = log(A, x, y) # auto convert
+    y2 = exp(A, x, v2)
+    w = log(M, x, z)
+    w2 = log(A, x, z; atol = 10^(-15))
     @testset "Types and Conversion" begin
         @test convert(typeof(M), A) == M
-        @test convert(typeof(A),M) == A
+        @test convert(typeof(A), M) == A
         @test is_decorator_manifold(A) == Val(true)
         @test base_manifold(A) == M
         @test base_manifold(base_manifold(A)) == base_manifold(A)
@@ -32,12 +39,12 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
         @test manifold_dimension(A) == 3
         for T in [ArrayMPoint, ArrayTVector, ArrayCoTVector]
             p = T(x)
-            @test convert(typeof(x),p) == x
-            @test convert(typeof(p),y) == T(y)
+            @test convert(typeof(x), p) == x
+            @test convert(typeof(p), y) == T(y)
             @test number_eltype(typeof(p)) == eltype(x)
             @test number_eltype(p) == eltype(x)
             @test typeof(allocate(p)) == typeof(p)
-            @test typeof(allocate(p,eltype(x))) == typeof(p)
+            @test typeof(allocate(p, eltype(x))) == typeof(p)
             @test allocate(p) isa T
             @test allocate(p, Float32) isa T
             @test number_eltype(allocate(p, Float32)) == Float32
@@ -45,8 +52,8 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
             @test similar(p, Float32) isa T
             @test number_eltype(similar(p, Float32)) == Float32
             q = allocate(p)
-            copyto!(q,p)
-            @test isapprox(A,q,p)
+            copyto!(q, p)
+            @test isapprox(A, q, p)
             @test ManifoldsBase.array_value(p) == x
             @test ManifoldsBase.array_value(x) == x
         end
@@ -55,10 +62,10 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
         for T in [ArrayTVector, ArrayCoTVector]
             a = T(v)
             b = T(w)
-            @test isapprox(A, a+b, T(v+w))
-            @test isapprox(A, (a-b), T(v-w) )
-            @test isapprox(A, -b, T(-w) )
-            @test isapprox(A, 2*a, T(2 .* v) )
+            @test isapprox(A, a + b, T(v + w))
+            @test isapprox(A, (a - b), T(v - w))
+            @test isapprox(A, -b, T(-w))
+            @test isapprox(A, 2 * a, T(2 .* v))
         end
     end
     @testset "Manifold functions" begin
@@ -66,7 +73,7 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
         @test isapprox(y2.value, y)
         @test distance(A, x, y) == distance(M, x, y)
         @test norm(A, x, v) == norm(M, x, v)
-        @test inner(A, x, v2, w2; atol=10^(-15)) == inner(M, x, v, w)
+        @test inner(A, x, v2, w2; atol = 10^(-15)) == inner(M, x, v, w)
         @test isapprox(A, x2, y2) == isapprox(M, x, y)
         @test isapprox(A, x, y) == isapprox(A, x2, y2)
         @test isapprox(A, x, v2, v2) == isapprox(M, x, v, v)
@@ -74,7 +81,7 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
         project_tangent!(A, v2s, x2, v2)
         @test isapprox(A, v2, v2s)
         y2s = similar(y2)
-        exp!(A,y2s,x2,v2)
+        exp!(A, y2s, x2, v2)
         @test isapprox(A, y2s, y2)
         log!(A, v2s, x, y)
         @test isapprox(A, x, v2s, v2)
@@ -88,8 +95,18 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, x, ::CustomArr
         @test isapprox(A, x, v2s, zero_tangent_vector(M, x))
         c = t -> x2
         v3 = similar(v2)
-        @test isapprox(A, x2, v2, vector_transport_along!(A, v3, x2, v2, c, ParallelTransport()))
-        @test isapprox(A, x2, v2, vector_transport_along(A, x2, v2, c, ManifoldsBase.ProjectionTransport()))
+        @test isapprox(
+            A,
+            x2,
+            v2,
+            vector_transport_along!(A, v3, x2, v2, c, ParallelTransport()),
+        )
+        @test isapprox(
+            A,
+            x2,
+            v2,
+            vector_transport_along(A, x2, v2, c, ManifoldsBase.ProjectionTransport()),
+        )
         @test injectivity_radius(A) == Inf
         @test injectivity_radius(A, x) == Inf
         @test injectivity_radius(A, ManifoldsBase.ExponentialRetraction()) == Inf

--- a/test/array_manifold.jl
+++ b/test/array_manifold.jl
@@ -10,7 +10,7 @@ ManifoldsBase.injectivity_radius(
 ) = 10.0
 ManifoldsBase.injectivity_radius(
     ::ManifoldsBase.DefaultManifold,
-    x,
+    p,
     ::CustomArrayManifoldRetraction,
 ) = 11.0
 

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -10,19 +10,24 @@ using Test
 struct CustomDefinedRetraction <: ManifoldsBase.AbstractRetractionMethod end
 struct CustomUndefinedRetraction <: ManifoldsBase.AbstractRetractionMethod end
 
-ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomDefinedRetraction) = 10.0
+ManifoldsBase.injectivity_radius(
+    ::ManifoldsBase.DefaultManifold,
+    ::CustomDefinedRetraction,
+) = 10.0
 
 @testset "Testing Default (Euclidean)" begin
     M = ManifoldsBase.DefaultManifold(3)
-    types = [Vector{Float64},
-             SizedVector{3, Float64},
-             MVector{3, Float64},
-             Vector{Float32},
-             SizedVector{3, Float32},
-             MVector{3, Float32},
-             Vector{Double64},
-             MVector{3, Double64},
-             SizedVector{3, Double64}]
+    types = [
+        Vector{Float64},
+        SizedVector{3,Float64},
+        MVector{3,Float64},
+        Vector{Float32},
+        SizedVector{3,Float32},
+        MVector{3,Float32},
+        Vector{Double64},
+        MVector{3,Double64},
+        SizedVector{3,Double64},
+    ]
 
     @test isa(manifold_dimension(M), Integer)
     @test manifold_dimension(M) ≥ 0
@@ -59,8 +64,8 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomDefine
 
             tv2 = log(M, pts[2], pts[1])
             @test isapprox(M, pts[2], exp(M, pts[1], tv1))
-            @test isapprox(M, pts[1], exp(M, pts[1], tv1, 0))
-            @test isapprox(M, pts[2], exp(M, pts[1], tv1, 1))
+            @test isapprox(M, pts[1], exp(M, pts[1], tv1, 0))
+            @test isapprox(M, pts[2], exp(M, pts[1], tv1, 1))
             @test isapprox(M, pts[1], exp(M, pts[2], tv2))
             @test is_manifold_point(M, retract(M, pts[1], tv1))
             @test isapprox(M, pts[1], retract(M, pts[1], tv1, 0))
@@ -72,9 +77,24 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomDefine
             retract!(M, new_pt, pts[1], tv1)
             @test is_manifold_point(M, new_pt)
             for x ∈ pts
-                @test isapprox(M, zero_tangent_vector(M, x), log(M, x, x); atol = eps(eltype(x)))
-                @test isapprox(M, zero_tangent_vector(M, x), inverse_retract(M, x, x); atol = eps(eltype(x)))
-                @test isapprox(M, zero_tangent_vector(M, x), inverse_retract(M, x, x, irm); atol = eps(eltype(x)))
+                @test isapprox(
+                    M,
+                    zero_tangent_vector(M, x),
+                    log(M, x, x);
+                    atol = eps(eltype(x)),
+                )
+                @test isapprox(
+                    M,
+                    zero_tangent_vector(M, x),
+                    inverse_retract(M, x, x);
+                    atol = eps(eltype(x)),
+                )
+                @test isapprox(
+                    M,
+                    zero_tangent_vector(M, x),
+                    inverse_retract(M, x, x, irm);
+                    atol = eps(eltype(x)),
+                )
             end
             zero_tangent_vector!(M, tv1, pts[1])
             @test isapprox(M, pts[1], tv1, zero_tangent_vector(M, pts[1]))
@@ -87,38 +107,46 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomDefine
             @test distance(M, pts[1], pts[2]) ≈ norm(M, pts[1], tv1)
 
             @testset "Geodesic interface test" begin
-                @test isapprox(M, geodesic(M, pts[1], tv1)(0.), pts[1])
-                @test isapprox(M, geodesic(M, pts[1], tv1)(1.), pts[2])
-                @test isapprox(M, geodesic(M, pts[1],tv1, 1.), pts[2])
-                @test isapprox(M, geodesic(M, pts[1],tv1, 1. /2), (pts[1]+pts[2])/2)
-                @test isapprox(M, shortest_geodesic(M, pts[1], pts[2])(0.), pts[1])
-                @test isapprox(M, shortest_geodesic(M, pts[1], pts[2])(1.), pts[2])
-                @test isapprox(M, shortest_geodesic(M, pts[1], pts[2], 0.), pts[1])
-                @test isapprox(M, shortest_geodesic(M, pts[1], pts[2], 1.), pts[2])
-                @test all(
-                    isapprox.(Ref(M), geodesic(M, pts[1], tv1, [0., 1. /2, 1.]),
-                        [pts[1], (pts[1]+pts[2])/2, pts[2]] )
-                    )
-                @test all(
-                    isapprox.(Ref(M), shortest_geodesic(M, pts[1], pts[2], [0., 1. /2, 1.]),
-                        [pts[1], (pts[1]+pts[2])/2, pts[2]] )
-                    )
+                @test isapprox(M, geodesic(M, pts[1], tv1)(0.0), pts[1])
+                @test isapprox(M, geodesic(M, pts[1], tv1)(1.0), pts[2])
+                @test isapprox(M, geodesic(M, pts[1], tv1, 1.0), pts[2])
+                @test isapprox(M, geodesic(M, pts[1], tv1, 1.0 / 2), (pts[1] + pts[2]) / 2)
+                @test isapprox(M, shortest_geodesic(M, pts[1], pts[2])(0.0), pts[1])
+                @test isapprox(M, shortest_geodesic(M, pts[1], pts[2])(1.0), pts[2])
+                @test isapprox(M, shortest_geodesic(M, pts[1], pts[2], 0.0), pts[1])
+                @test isapprox(M, shortest_geodesic(M, pts[1], pts[2], 1.0), pts[2])
+                @test all(isapprox.(
+                    Ref(M),
+                    geodesic(M, pts[1], tv1, [0.0, 1.0 / 2, 1.0]),
+                    [pts[1], (pts[1] + pts[2]) / 2, pts[2]],
+                ))
+                @test all(isapprox.(
+                    Ref(M),
+                    shortest_geodesic(M, pts[1], pts[2], [0.0, 1.0 / 2, 1.0]),
+                    [pts[1], (pts[1] + pts[2]) / 2, pts[2]],
+                ))
             end
 
             @testset "basic linear algebra in tangent space" begin
-                @test isapprox(M, pts[1], 0*tv1, zero_tangent_vector(M, pts[1]); atol = eps(eltype(pts[1])))
-                @test isapprox(M, pts[1], 2*tv1, tv1+tv1)
-                @test isapprox(M, pts[1], 0*tv1, tv1-tv1)
-                @test isapprox(M, pts[1], (-1)*tv1, -tv1)
+                @test isapprox(
+                    M,
+                    pts[1],
+                    0 * tv1,
+                    zero_tangent_vector(M, pts[1]);
+                    atol = eps(eltype(pts[1])),
+                )
+                @test isapprox(M, pts[1], 2 * tv1, tv1 + tv1)
+                @test isapprox(M, pts[1], 0 * tv1, tv1 - tv1)
+                @test isapprox(M, pts[1], (-1) * tv1, -tv1)
             end
 
             @testset "broadcasted linear algebra in tangent space" begin
-                @test isapprox(M, pts[1], 3*tv1, 2 .* tv1 .+ tv1)
+                @test isapprox(M, pts[1], 3 * tv1, 2 .* tv1 .+ tv1)
                 @test isapprox(M, pts[1], -tv1, tv1 .- 2 .* tv1)
                 @test isapprox(M, pts[1], -tv1, .-tv1)
                 v = similar(tv1)
                 v .= 2 .* tv1 .+ tv1
-                @test v ≈ 3*tv1
+                @test v ≈ 3 * tv1
             end
 
             @testset "project_point test" begin
@@ -154,26 +182,26 @@ ManifoldsBase.injectivity_radius(::ManifoldsBase.DefaultManifold, ::CustomDefine
             end
 
             @testset "ForwardDiff support" begin
-                exp_f(t) = distance(M, pts[1], exp(M, pts[1], t*tv1))
+                exp_f(t) = distance(M, pts[1], exp(M, pts[1], t * tv1))
                 d12 = distance(M, pts[1], pts[2])
                 for t ∈ 0.1:0.1:0.9
                     @test d12 ≈ ForwardDiff.derivative(exp_f, t)
                 end
 
-                retract_f(t) = distance(M, pts[1], retract(M, pts[1], t*tv1))
+                retract_f(t) = distance(M, pts[1], retract(M, pts[1], t * tv1))
                 for t ∈ 0.1:0.1:0.9
                     @test ForwardDiff.derivative(retract_f, t) ≥ 0
                 end
             end
 
-            isa(pts[1], Union{Vector, SizedVector}) && @testset "ReverseDiff support" begin
-                exp_f(t) = distance(M, pts[1], exp(M, pts[1], t[1]*tv1))
+            isa(pts[1], Union{Vector,SizedVector}) && @testset "ReverseDiff support" begin
+                exp_f(t) = distance(M, pts[1], exp(M, pts[1], t[1] * tv1))
                 d12 = distance(M, pts[1], pts[2])
                 for t ∈ 0.1:0.1:0.9
                     @test d12 ≈ ReverseDiff.gradient(exp_f, [t])[1]
                 end
 
-                retract_f(t) = distance(M, pts[1], retract(M, pts[1], t[1]*tv1))
+                retract_f(t) = distance(M, pts[1], retract(M, pts[1], t[1] * tv1))
                 for t ∈ 0.1:0.1:0.9
                     @test ReverseDiff.gradient(retract_f, [t])[1] ≥ 0
                 end

--- a/test/empty_manifold.jl
+++ b/test/empty_manifold.jl
@@ -6,7 +6,7 @@ struct NonManifold <: Manifold end
 struct NonMPoint <: MPoint end
 struct NonTVector <: TVector end
 struct NonCoTVector <: CoTVector end
-*(t::Float64, v::NonTVector) = v
+*(t::Float64, X::NonTVector) = X
 @testset "Manifold with empty implementation" begin
     m = NonManifold()
     p = NonMPoint()

--- a/test/empty_manifold.jl
+++ b/test/empty_manifold.jl
@@ -6,7 +6,7 @@ struct NonManifold <: Manifold end
 struct NonMPoint <: MPoint end
 struct NonTVector <: TVector end
 struct NonCoTVector <: CoTVector end
-*(t::Float64,v::NonTVector) = v
+*(t::Float64, v::NonTVector) = v
 @testset "Manifold with empty implementation" begin
     m = NonManifold()
     p = NonMPoint()
@@ -19,20 +19,20 @@ struct NonCoTVector <: CoTVector end
 
     # by default isapprox compares given points or vectors
     @test isapprox(m, [0], [0])
-    @test isapprox(m, [0], [0]; atol=1e-6)
+    @test isapprox(m, [0], [0]; atol = 1e-6)
     @test !isapprox(m, [0], [1])
-    @test !isapprox(m, [0], [1]; atol=1e-6)
+    @test !isapprox(m, [0], [1]; atol = 1e-6)
     @test isapprox(m, [0], [0], [0])
-    @test isapprox(m, [0], [0], [0]; atol=1e-6)
+    @test isapprox(m, [0], [0], [0]; atol = 1e-6)
     @test !isapprox(m, [0], [0], [1])
-    @test !isapprox(m, [0], [0], [1]; atol=1e-6)
+    @test !isapprox(m, [0], [0], [1]; atol = 1e-6)
 
     exp_retr = ManifoldsBase.ExponentialRetraction()
 
     @test_throws ErrorException retract!(m, p, p, v)
     @test_throws ErrorException retract!(m, p, p, v, exp_retr)
-    @test_throws ErrorException retract!(m, p, p, [0.0], 0.)
-    @test_throws ErrorException retract!(m, p, p, [0.0], 0., exp_retr)
+    @test_throws ErrorException retract!(m, p, p, [0.0], 0.0)
+    @test_throws ErrorException retract!(m, p, p, [0.0], 0.0, exp_retr)
     @test_throws ErrorException retract!(m, [0], [0], [0])
     @test_throws ErrorException retract!(m, [0], [0], [0], exp_retr)
     @test_throws ErrorException retract!(m, [0], [0], [0], 0.0)
@@ -93,12 +93,24 @@ struct NonCoTVector <: CoTVector end
 
     @test_throws ErrorException vector_transport_to!(m, [0], [0], [0], [0])
     @test_throws ErrorException vector_transport_to(m, [0], [0], [0])
-    @test_throws ErrorException vector_transport_to!(m, [0], [0], [0], ProjectionTransport())
+    @test_throws ErrorException vector_transport_to!(
+        m,
+        [0],
+        [0],
+        [0],
+        ProjectionTransport(),
+    )
 
     @test_throws ErrorException vector_transport_direction!(m, [0], [0], [0], [0])
     @test_throws ErrorException vector_transport_direction(m, [0], [0], [0])
 
-    @test_throws ErrorException ManifoldsBase.vector_transport_along!(m, [0], [0], [0], x -> x)
+    @test_throws ErrorException ManifoldsBase.vector_transport_along!(
+        m,
+        [0],
+        [0],
+        [0],
+        x -> x,
+    )
     @test_throws ErrorException ManifoldsBase.vector_transport_along(m, [0], [0], x -> x)
 
     @test_throws ErrorException injectivity_radius(m)
@@ -109,12 +121,12 @@ struct NonCoTVector <: CoTVector end
     @test_throws ErrorException zero_tangent_vector(m, [0])
 
     @test check_manifold_point(m, [0]) === nothing
-    @test_throws ErrorException check_manifold_point(m,p)
+    @test_throws ErrorException check_manifold_point(m, p)
     @test is_manifold_point(m, [0])
     @test check_manifold_point(m, [0]) == nothing
 
     @test check_tangent_vector(m, [0], [0]) === nothing
-    @test_throws ErrorException check_tangent_vector(m,p,v)
+    @test_throws ErrorException check_tangent_vector(m, p, v)
     @test is_tangent_vector(m, [0], [0])
     @test check_tangent_vector(m, [0], [0]) == nothing
 


### PR DESCRIPTION
Similar to the rework in `Manifolds` the documentation is unified here and notation is adapted. A new `base_manifold` function is implemented, that is non-breaking but now also allows to only check for a base up to a limit of `levels` (by default all levels).