### PR TITLE
Fixing typed kwargs in decorator macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ branches:
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/ # build tagged releases
 jobs:
   allow_failures:
-    - julia: 1.4
     - julia: nightly
 after_success:
 - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,8 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.1
-  - julia_version: 1.2
   - julia_version: 1.3
+  - julia_version: 1.4
   - julia_version: nightly
 
 platform:

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -42,7 +42,11 @@ function _split_signature(sig::Expr)
         if kwarg.head === :...
             return kwarg
         else
-            kwargname = kwarg.args[1]
+            if isa(kwarg.args[1], Symbol)
+                kwargname = kwarg.args[1]
+            else
+                kwargname = kwarg.args[1].args[1]
+            end
             return :($kwargname = $kwargname)
         end
     end

--- a/test/decorator_manifold.jl
+++ b/test/decorator_manifold.jl
@@ -74,6 +74,10 @@ end
 # the following then ignores the previous definition and passes again to the parent above
 decorator_transparent_dispatch(::typeof(test10), M::TestDecorator3, args...) = Val(:parent)
 
+@decorator_transparent_function function test11(M::TestDecorator3, p::TP; a::Int=0) where {TP}
+    return 15*a
+end
+
 @testset "Testing decorator manifold functions" begin
     M = ManifoldsBase.DefaultManifold(3)
     A = ArrayManifold(M)
@@ -135,4 +139,5 @@ decorator_transparent_dispatch(::typeof(test10), M::TestDecorator3, args...) = V
     @test test9(TestDecorator3(TD), p; a = 1000) == 1109
     @test test9(TestDecorator3(TD), p; a = 1000, b = 10000) == 11109
     @test test10(TestDecorator3(TD), p; a = 11) == 110
+    @test test11(TestDecorator3(TD), p; a = 12) == 180
 end


### PR DESCRIPTION
I've encountered a bug in our decorator macro code (it didn't work where a typed kwarg was on the list) while updating my differentiation PR in Manifolds.jl. This seems to fix it.